### PR TITLE
Fix required PIP parameter input to use defaults

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -27,7 +27,7 @@ jobs:
           skip_after_successful_duplicate: 'true'
           cancel_others: 'true'
           paths_ignore: '["**/**.yml", "**/data/**"]'
-          do_not_skip: '["pull_request", "workflow_dispatch"]'
+          do_not_skip: '["workflow_dispatch"]'
 
   fmt:
     needs: skip_check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           skip_after_successful_duplicate: 'true'
           cancel_others: 'true'
           paths_ignore: '["**/**.yml", "**/data/**"]'
-          do_not_skip: '["pull_request", "workflow_dispatch"]'
+          do_not_skip: '["workflow_dispatch"]'
 
   check:
     name: cargo check

--- a/phylo/src/likelihood/tests.rs
+++ b/phylo/src/likelihood/tests.rs
@@ -33,7 +33,7 @@ fn test_subst_model<Q: QMatrix + QMatrixMaker>(
     let seqs = Sequences::with_alphabet(records.clone(), alpha);
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
     let info = PIB::build_from_objects(seqs, tree).unwrap();
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     SCB::new(model, info).build().unwrap()
 }
 
@@ -148,7 +148,7 @@ fn alphabet_mismatch_subst_model_template<Q: QMatrix + QMatrixMaker>(
     let seqs = Sequences::with_alphabet(records, alpha);
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
     let info = PIB::build_from_objects(seqs, tree).unwrap();
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let res = SCB::new(model, info).build();
     assert!(res.is_err());
     assert!(res.err().unwrap().to_string().contains("Alphabet mismatch"));

--- a/phylo/src/likelihood/tests.rs
+++ b/phylo/src/likelihood/tests.rs
@@ -83,7 +83,7 @@ fn test_pip_model<Q: QMatrix + QMatrixMaker>(
     let seqs = Sequences::with_alphabet(records.clone(), alpha);
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
     let info = PIB::build_from_objects(seqs, tree).unwrap();
-    let model = PIPModel::<Q>::new(freqs, params).unwrap();
+    let model = PIPModel::<Q>::new(freqs, params);
     PIPCB::new(model, info).build().unwrap()
 }
 
@@ -191,7 +191,7 @@ fn alphabet_mismatch_subst_pip_template<Q: QMatrix + QMatrixMaker>(
     let seqs = Sequences::with_alphabet(records.clone(), alpha);
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
     let info = PIB::build_from_objects(seqs, tree).unwrap();
-    let model = PIPModel::<Q>::new(freqs, params).unwrap();
+    let model = PIPModel::<Q>::new(freqs, params);
     let res = PIPCB::new(model, info).build();
     assert!(res.is_err());
     assert!(res.err().unwrap().to_string().contains("Alphabet mismatch"));

--- a/phylo/src/optimisers/blen_optimiser_tests.rs
+++ b/phylo/src/optimisers/blen_optimiser_tests.rs
@@ -20,8 +20,7 @@ fn branch_opt_likelihood_increase_pip() {
     let model = PIPModel::<GTR>::new(
         &[0.25, 0.25, 0.25, 0.25],
         &[14.142_1, 0.1414, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-    )
-    .unwrap();
+    );
     let c = PIPCB::new(model.clone(), info.clone()).build().unwrap();
     assert_relative_eq!(c.cost(), -5664.780425829528, epsilon = 1e-6);
     let o = BranchOptimiser::new(c.clone()).run().unwrap();

--- a/phylo/src/optimisers/blen_optimiser_tests.rs
+++ b/phylo/src/optimisers/blen_optimiser_tests.rs
@@ -48,8 +48,7 @@ fn branch_opt_likelihood_increase_gtr() {
     let info = PIB::with_attrs(fldr.join("GTR/gtr.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let gtr =
-        SubstModel::<GTR>::new(&[0.25, 0.25, 0.25, 0.25], &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0]).unwrap();
+    let gtr = SubstModel::<GTR>::new(&[0.25, 0.25, 0.25, 0.25], &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0]);
     let o = BranchOptimiser::new(SCB::new(gtr.clone(), info.clone()).build().unwrap())
         .run()
         .unwrap();
@@ -68,7 +67,7 @@ fn branch_optimiser_against_phyml() {
     let info = PIB::with_attrs(fldr.join("GTR/gtr.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let model = SubstModel::<JC69>::new(&[], &[]);
     let o = BranchOptimiser::new(SCB::new(model.clone(), info.clone()).build().unwrap())
         .run()
         .unwrap();

--- a/phylo/src/optimisers/model_optimiser_tests.rs
+++ b/phylo/src/optimisers/model_optimiser_tests.rs
@@ -352,8 +352,7 @@ fn arpip_example() {
     let pip_gtr = PIPModel::<GTR>::new(
         &[0.25, 0.25, 0.25, 0.25],
         &[0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-    )
-    .unwrap();
+    );
     let c = PIPCostBuilder::new(pip_gtr.clone(), info.clone())
         .build()
         .unwrap();
@@ -370,7 +369,7 @@ fn arpip_example() {
     assert_ne!(o.cost.freqs(), pip_gtr.freqs());
     assert_eq!(o.final_cost, o.cost.cost());
 
-    let pip_gtr = PIPModel::<GTR>::new(o.cost.freqs().as_slice(), o.cost.params()).unwrap();
+    let pip_gtr = PIPModel::<GTR>::new(o.cost.freqs().as_slice(), o.cost.params());
     let c = PIPCostBuilder::new(pip_gtr, info.clone()).build().unwrap();
     assert_eq!(o.final_cost, c.cost());
 
@@ -387,8 +386,7 @@ fn pip_propip_example() {
     let pip_gtr = PIPModel::<GTR>::new(
         &[0.25, 0.25, 0.25, 0.25],
         &[14.142_1, 0.1414, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-    )
-    .unwrap();
+    );
     let c = PIPCostBuilder::new(pip_gtr.clone(), info).build().unwrap();
     let initial_logl = c.cost();
 
@@ -413,7 +411,7 @@ fn pip_vs_python_no_gaps() {
     .build()
     .unwrap();
 
-    let pip_hky = PIPModel::<HKY>::new(&[0.25; 4], &[1.2, 0.45, 1.0]).unwrap();
+    let pip_hky = PIPModel::<HKY>::new(&[0.25; 4], &[1.2, 0.45, 1.0]);
 
     let c = PIPCostBuilder::new(pip_hky, info).build().unwrap();
     assert_relative_eq!(c.cost(), -361.18634412281443, epsilon = 1e-7); // value from the python script
@@ -439,15 +437,14 @@ fn pip_gtr_optimisation() {
     let pip_gtr = PIPModel::<GTR>::new(
         &[0.24720, 0.35320, 0.29540, 0.10420],
         &[0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-    )
-    .unwrap();
+    );
     let c = PIPCostBuilder::new(pip_gtr, info.clone()).build().unwrap();
 
     let initial_logl = c.cost();
     let pip_o = ModelOptimiser::new(c, FrequencyOptimisation::Fixed)
         .run()
         .unwrap();
-    let pip_gtr = PIPModel::<GTR>::new(pip_o.cost.freqs().as_slice(), pip_o.cost.params()).unwrap();
+    let pip_gtr = PIPModel::<GTR>::new(pip_o.cost.freqs().as_slice(), pip_o.cost.params());
 
     let c = PIPCostBuilder::new(pip_gtr, info.clone()).build().unwrap();
     assert_eq!(pip_o.final_cost, c.cost());
@@ -469,8 +466,7 @@ fn pip_gtr_vs_gtr_params() {
     let pip_gtr = PIPModel::<GTR>::new(
         &[0.24720, 0.35320, 0.29540, 0.10420],
         &[0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-    )
-    .unwrap();
+    );
     let c = PIPCostBuilder::new(pip_gtr, info.clone()).build().unwrap();
     let pip_o = ModelOptimiser::new(c, FrequencyOptimisation::Fixed)
         .run()
@@ -494,7 +490,7 @@ fn pip_protein_example() {
     let info = PIB::with_attrs(fldr.join("seqs.fasta"), fldr.join("true_tree.newick"))
         .build()
         .unwrap();
-    let pip = PIPModel::<WAG>::new(&[], &[2.0, 0.1]).unwrap();
+    let pip = PIPModel::<WAG>::new(&[], &[2.0, 0.1]);
     let c = PIPCostBuilder::new(pip, info).build().unwrap();
     let initial_logl = c.cost();
     let o = ModelOptimiser::new(c, FrequencyOptimisation::Empirical)

--- a/phylo/src/optimisers/model_optimiser_tests.rs
+++ b/phylo/src/optimisers/model_optimiser_tests.rs
@@ -19,7 +19,7 @@ fn likelihood_improves_k80() {
     let info = PIB::with_attrs(fldr.join("K80/K80.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<K80>::new(&[], &[4.0, 1.0]).unwrap();
+    let model = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
 
     let c = SCB::new(model, info.clone()).build().unwrap();
     let unopt_logl = c.cost();
@@ -28,7 +28,7 @@ fn likelihood_improves_k80() {
         .unwrap();
     assert!(o.final_cost > unopt_logl);
 
-    let model = SubstModel::<K80>::new(o.cost.freqs().into(), o.cost.params()).unwrap();
+    let model = SubstModel::<K80>::new(o.cost.freqs().into(), o.cost.params());
     let c2 = SCB::new(model, info).build().unwrap();
     assert_relative_eq!(o.initial_cost, unopt_logl);
     assert_relative_eq!(o.final_cost, o.cost.cost());
@@ -43,7 +43,7 @@ fn frequencies_unchanged_k80() {
     let info = PIB::with_attrs(fldr.join("K80/K80.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<K80>::new(&[], &[4.0, 1.0]).unwrap();
+    let model = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(model.clone(), info).build().unwrap();
     let initial_logl = c.cost();
     let o = ModelOptimiser::new(c, FrequencyOptimisation::Empirical)
@@ -62,7 +62,7 @@ fn parameter_change_k80() {
     let info = PIB::with_attrs(fldr.join("K80/K80.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<K80>::new(&[], &[4.0, 1.0]).unwrap();
+    let model = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(model.clone(), info).build().unwrap();
     let initial_logl = c.cost();
     let o = ModelOptimiser::new(c, FrequencyOptimisation::Fixed)
@@ -81,14 +81,13 @@ fn gtr_on_k80_data() {
     let info = PIB::with_attrs(fldr.join("K80/K80.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<GTR>::new(&[0.25, 0.35, 0.3, 0.1], &[0.88, 0.03, 0.00001, 0.07, 0.02])
-        .unwrap();
+    let model = SubstModel::<GTR>::new(&[0.25, 0.35, 0.3, 0.1], &[0.88, 0.03, 0.00001, 0.07, 0.02]);
     let c = SCB::new(model.clone(), info.clone()).build().unwrap();
     let o_gtr = ModelOptimiser::new(c, FrequencyOptimisation::Empirical)
         .run()
         .unwrap();
 
-    let model = SubstModel::<K80>::new(&[], &[4.0, 1.0]).unwrap();
+    let model = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(model.clone(), info.clone()).build().unwrap();
     let o_k80 = ModelOptimiser::new(c, FrequencyOptimisation::Empirical)
         .run()
@@ -108,7 +107,7 @@ fn improved_logl_fixed_freqs_template<Q: QMatrix + QMatrixMaker>() {
     let info = PIB::with_attrs(fldr.join("GTR/gtr.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let model = SubstModel::<Q>::new(&[], &[]);
 
     let c = SCB::new(model.clone(), info).build().unwrap();
     let initial_logl = c.cost();
@@ -137,7 +136,7 @@ fn improved_logl_empirical_freqs_template<Q: QMatrix + QMatrixMaker>() {
     let info = PIB::with_attrs(fldr.join("GTR/gtr.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let model = SubstModel::<Q>::new(&[], &[]);
 
     let c = SCB::new(model.clone(), info).build().unwrap();
     let initial_logl = c.cost();
@@ -170,24 +169,21 @@ fn gtr_vs_phyml() {
     let phyml_model = SubstModel::<GTR>::new(
         &[0.24720, 0.35320, 0.29540, 0.10420],
         &[1.0, 0.031184397, 0.000100000, 0.077275972, 0.041508690, 1.0],
-    )
-    .unwrap();
+    );
     let phyml_logl = SCB::new(phyml_model, info.clone()).build().unwrap().cost();
     assert_relative_eq!(phyml_logl, -3474.48083, epsilon = 1.0e-5);
 
     let paml_model = SubstModel::<GTR>::new(
         &[0.25318, 0.32894, 0.31196, 0.10592],
         &[0.88892, 0.03190, 0.00001, 0.07102, 0.02418, 1.0],
-    )
-    .unwrap(); // Original input to paml
+    ); // Original input to paml
     let paml_logl = SCB::new(paml_model, info.clone()).build().unwrap().cost();
     assert!(phyml_logl > paml_logl);
 
     let model = SubstModel::<GTR>::new(
         &[0.24720, 0.35320, 0.29540, 0.10420],
         &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-    )
-    .unwrap();
+    );
     let c = SCB::new(model, info.clone()).build().unwrap();
     let o = ModelOptimiser::new(c, FrequencyOptimisation::Fixed)
         .run()
@@ -209,14 +205,14 @@ fn k80_vs_phyml() {
         .build()
         .unwrap();
     // Optimized parameters from PhyML
-    let phyml_model = SubstModel::<K80>::new(&[], &[19.432093]).unwrap();
+    let phyml_model = SubstModel::<K80>::new(&[], &[19.432093]);
     let phyml_logl = SCB::new(phyml_model.clone(), info.clone())
         .build()
         .unwrap()
         .cost();
     assert_relative_eq!(phyml_logl, -3629.2205979421, epsilon = 1.0e-5);
 
-    let model = SubstModel::<K80>::new(&[], &[2.0, 1.0]).unwrap();
+    let model = SubstModel::<K80>::new(&[], &[2.0, 1.0]);
     let o = ModelOptimiser::new(
         SCB::new(model, info.clone()).build().unwrap(),
         FrequencyOptimisation::Fixed,
@@ -241,7 +237,7 @@ fn hky_vs_phyml() {
     let info = PIB::with_attrs(fldr.join("GTR/gtr.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<HKY>::new(&[0.25, 0.25, 0.25, 0.25], &[2.0]).unwrap();
+    let model = SubstModel::<HKY>::new(&[0.25, 0.25, 0.25, 0.25], &[2.0]);
     let o = ModelOptimiser::new(
         SCB::new(model, info.clone()).build().unwrap(),
         FrequencyOptimisation::Empirical,
@@ -256,8 +252,7 @@ fn hky_vs_phyml() {
     assert!(o2.iterations < 10);
 
     // Optimized parameters from PhyML
-    let phyml_model =
-        SubstModel::<HKY>::new(&[0.24720, 0.35320, 0.29540, 0.10420], &[20.357397]).unwrap();
+    let phyml_model = SubstModel::<HKY>::new(&[0.24720, 0.35320, 0.29540, 0.10420], &[20.357397]);
     let phyml_logl = SCB::new(phyml_model.clone(), info).build().unwrap().cost();
     assert_relative_eq!(phyml_logl, -3483.9223510041406, epsilon = 1.0e-5);
 
@@ -274,7 +269,7 @@ fn frequencies_fixed_opt_gtr() {
     let info = PIB::with_attrs(fldr.join("GTR/gtr.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<GTR>::new(&[0.25, 0.35, 0.3, 0.1], &[1.0; 5]).unwrap();
+    let model = SubstModel::<GTR>::new(&[0.25, 0.35, 0.3, 0.1], &[1.0; 5]);
     let o = ModelOptimiser::new(
         SCB::new(model, info.clone()).build().unwrap(),
         FrequencyOptimisation::Fixed,
@@ -295,7 +290,7 @@ fn frequencies_fixed_protein_template<Q: QMatrix + QMatrixMaker>() {
     )
     .build()
     .unwrap();
-    let model = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let model = SubstModel::<Q>::new(&[], &[]);
     let c = SCB::new(model.clone(), info).build().unwrap();
 
     let initial_llik = c.cost();
@@ -324,7 +319,7 @@ fn frequencies_empirical_protein_template<Q: QMatrix + QMatrixMaker>() {
     )
     .build()
     .unwrap();
-    let model = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let model = SubstModel::<Q>::new(&[], &[]);
     let c = SCB::new(model.clone(), info).build().unwrap();
 
     let initial_llik = c.cost();
@@ -475,8 +470,7 @@ fn pip_gtr_vs_gtr_params() {
     let gtr = SubstModel::<GTR>::new(
         &[0.24720, 0.35320, 0.29540, 0.10420],
         &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-    )
-    .unwrap();
+    );
     let c = SCB::new(gtr, info).build().unwrap();
     let o = ModelOptimiser::new(c, FrequencyOptimisation::Fixed)
         .run()

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -278,7 +278,7 @@ fn pip_vs_subst_dna_tree() {
         .run()
         .unwrap();
 
-    let pip = PIPModel::<K80>::new(&[], &[0.5, 0.4, 4.0]).unwrap();
+    let pip = PIPModel::<K80>::new(&[], &[0.5, 0.4, 4.0]);
     let pip_res = TopologyOptimiser::new(PIPCB::new(pip.clone(), info).build().unwrap())
         .run()
         .unwrap();
@@ -322,7 +322,7 @@ fn wag_nogaps_pip_vs_subst_tree_nj_start() {
     let wag_tree_file = fldr.join("jati_wag_nogap_pip_vs_wag.newick");
 
     let info = PIB::new(seq_file.clone()).build().unwrap();
-    let pip = PIPModel::<WAG>::new(&[], &[50.0, 0.1]).unwrap();
+    let pip = PIPModel::<WAG>::new(&[], &[50.0, 0.1]);
     let wag = SubstModel::<WAG>::new(&[], &[]).unwrap();
     let c_pip = PIPCB::new(pip.clone(), info.clone()).build().unwrap();
     let c_wag = SCB::new(wag.clone(), info.clone()).build().unwrap();
@@ -391,7 +391,7 @@ fn protein_pip_optimise_model_tree() {
     let fldr = Path::new("./data/phyml_protein_example/");
     let seq_file = fldr.join("seqs.fasta");
 
-    let pip = PIPModel::<WAG>::new(&[], &[1.4, 0.5]).unwrap();
+    let pip = PIPModel::<WAG>::new(&[], &[1.4, 0.5]);
 
     let tree_file = fldr.join("jati_pip_nj_start.newick");
     let result =
@@ -424,7 +424,7 @@ fn protein_pip_optimise_model_tree() {
             o.cost.info
         };
 
-    let pip_opt = PIPModel::<WAG>::new(&[], &[49.56941, 0.09352]).unwrap();
+    let pip_opt = PIPModel::<WAG>::new(&[], &[49.56941, 0.09352]);
     assert_eq!(result_model_opt.tree.robinson_foulds(&result.tree), 0);
 
     let pip_opt_new_res_logl = PIPCB::new(pip_opt.clone(), result_model_opt.clone())
@@ -499,7 +499,7 @@ fn protein_pip_vs_phyml_empirical_freqs() {
     let tree_file = fldr.join("jati_pip_wag_empirical.newick");
 
     let info = PIB::new(seq_file.clone()).build().unwrap();
-    let wag = PIPModel::<WAG>::new(&[], &[1.0, 2.0]).unwrap();
+    let wag = PIPModel::<WAG>::new(&[], &[1.0, 2.0]);
     let c_wag = PIPCB::new(wag.clone(), info.clone()).build().unwrap();
 
     let unopt_logl = c_wag.cost();

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -27,7 +27,7 @@ fn k80_simple() {
         record!("D", b"TTATATATAT"),
     ]);
     let info = PIB::build_from_objects(sequences, tree).unwrap();
-    let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]).unwrap();
+    let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(k80.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
     let o = TopologyOptimiser::new(c).run().unwrap();
@@ -48,7 +48,7 @@ fn k80_sim_data_from_given() {
     let info = PIB::with_attrs(fldr.join("K80.fasta"), fldr.join("../tree.newick"))
         .build()
         .unwrap();
-    let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]).unwrap();
+    let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(k80.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
     let o = TopologyOptimiser::new(c).run().unwrap();
@@ -68,7 +68,7 @@ fn k80_sim_data_from_nj() {
     // Check that optimisation on k80 data improves k80 likelihood when starting from an NJ tree
     let fldr = Path::new("./data/sim/K80");
     let info = PIB::new(fldr.join("K80.fasta")).build().unwrap();
-    let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]).unwrap();
+    let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(k80.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
     let o = TopologyOptimiser::new(c).run().unwrap();
@@ -90,7 +90,7 @@ fn k80_sim_data_vs_phyml() {
     let info = PIB::with_attrs(fldr.join("K80/K80.fasta"), fldr.join("tree.newick"))
         .build()
         .unwrap();
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let c = SCB::new(jc69.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
     let o = TopologyOptimiser::new(c).run().unwrap();
@@ -137,7 +137,7 @@ fn k80_sim_data_vs_phyml_wrong_start() {
     let info = PIB::with_attrs(fldr.join("K80/K80.fasta"), fldr.join("wrong_tree.newick"))
         .build()
         .unwrap();
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let c = SCB::new(jc69.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
     let o = TopologyOptimiser::new(c).run().unwrap();
@@ -180,7 +180,7 @@ fn wag_no_gaps_vs_phyml_given_tree_start() {
     let true_tree_file = fldr.join("true_tree.newick");
     let tree_file = fldr.join("jati_wag_nogap.newick");
 
-    let model = SubstModel::<WAG>::new(&[], &[]).unwrap();
+    let model = SubstModel::<WAG>::new(&[], &[]);
     let info = PIB::with_attrs(seq_file.clone(), true_tree_file.clone())
         .build()
         .unwrap();
@@ -228,7 +228,7 @@ fn wag_no_gaps_vs_phyml_nj_tree_start() {
     let seq_file = fldr.join("nogap_seqs.fasta");
     let tree_file = fldr.join("jati_wag_nogap_nj_start.newick");
 
-    let model = SubstModel::<WAG>::new(&[], &[]).unwrap();
+    let model = SubstModel::<WAG>::new(&[], &[]);
     let info = PIB::new(seq_file.clone()).build().unwrap();
     let c = SCB::new(model.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
@@ -273,7 +273,7 @@ fn pip_vs_subst_dna_tree() {
     let info = PIB::with_attrs(fldr.join("K80/K80.fasta"), fldr.join("wrong_tree.newick"))
         .build()
         .unwrap();
-    let k80 = SubstModel::<K80>::new(&[], &[4.0]).unwrap();
+    let k80 = SubstModel::<K80>::new(&[], &[4.0]);
     let k80_res = TopologyOptimiser::new(SCB::new(k80.clone(), info.clone()).build().unwrap())
         .run()
         .unwrap();
@@ -323,7 +323,7 @@ fn wag_nogaps_pip_vs_subst_tree_nj_start() {
 
     let info = PIB::new(seq_file.clone()).build().unwrap();
     let pip = PIPModel::<WAG>::new(&[], &[50.0, 0.1]);
-    let wag = SubstModel::<WAG>::new(&[], &[]).unwrap();
+    let wag = SubstModel::<WAG>::new(&[], &[]);
     let c_pip = PIPCB::new(pip.clone(), info.clone()).build().unwrap();
     let c_wag = SCB::new(wag.clone(), info.clone()).build().unwrap();
 
@@ -454,7 +454,7 @@ fn protein_wag_vs_phyml_empirical_freqs() {
     let tree_file = fldr.join("jati_wag_empirical.newick");
 
     let info = PIB::new(seq_file.clone()).build().unwrap();
-    let wag = SubstModel::<WAG>::new(&[], &[]).unwrap();
+    let wag = SubstModel::<WAG>::new(&[], &[]);
     let c_wag = SCB::new(wag.clone(), info.clone()).build().unwrap();
 
     let unopt_logl = c_wag.cost();
@@ -546,7 +546,7 @@ fn protein_wag_vs_phyml_fixed_freqs() {
     let fldr = Path::new("./data/phyml_protein_example/");
     let seq_file = fldr.join("seqs.fasta");
     let tree_file = fldr.join("jati_wag_fixed.newick");
-    let wag = SubstModel::<WAG>::new(&[], &[]).unwrap();
+    let wag = SubstModel::<WAG>::new(&[], &[]);
 
     let result =
         if let Ok(precomputed) = PIB::with_attrs(seq_file.clone(), tree_file.clone()).build() {

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -116,26 +116,30 @@ fn pip_dna_hky_as_k80() {
 }
 
 #[cfg(test)]
-fn pip_too_few_params_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
+fn pip_too_few_params_template<Q: QMatrix + QMatrixMaker>(
+    freqs: &[f64],
+    params: &[f64],
+    expected: &[f64],
+) {
     let model = PIPModel::<Q>::new(freqs, params);
     assert_eq!(model.params().len(), 2);
-    assert_eq!(model.params(), &[0.2, 1.5]);
+    assert_eq!(model.params(), expected);
 }
 
 #[test]
 fn pip_dna_too_few_params() {
     // Not providing DNA model parameters makes no difference as defaults are taken
-    pip_too_few_params_template::<JC69>(&[], &[0.2]);
-    pip_too_few_params_template::<K80>(&[], &[0.2]);
-    pip_too_few_params_template::<HKY>(&[0.22, 0.26, 0.33, 0.19], &[0.2]);
+    pip_too_few_params_template::<JC69>(&[], &[0.2], &[0.2, 1.5]);
+    pip_too_few_params_template::<K80>(&[], &[], &[1.5, 1.5]);
+    pip_too_few_params_template::<HKY>(&[0.22, 0.26, 0.33, 0.19], &[0.6], &[0.6, 1.5]);
 }
 
 #[test]
 fn pip_protein_too_few_params() {
     // Not providing substitution model parameters makes no difference as defaults are taken
-    pip_too_few_params_template::<WAG>(&[], &[0.2]);
-    pip_too_few_params_template::<HIVB>(&[], &[0.2]);
-    pip_too_few_params_template::<BLOSUM>(&[0.22, 0.26, 0.33, 0.19], &[0.2]);
+    pip_too_few_params_template::<WAG>(&[], &[0.2], &[0.2, 1.5]);
+    pip_too_few_params_template::<HIVB>(&[], &[1.5], &[1.5, 1.5]);
+    pip_too_few_params_template::<BLOSUM>(&[0.22, 0.26, 0.33, 0.19], &[], &[1.5, 1.5]);
 }
 
 #[test]

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -26,7 +26,7 @@ const UNNORMALIZED_PIP_HKY_Q: [f64; 25] = [
 #[cfg(test)]
 fn compare_pip_subst_rates_template<Q: QMatrix + QMatrixMaker>(chars: &[u8]) {
     let pip_model = PIPModel::<Q>::new(&[], &[0.1, 0.4]);
-    let subst_model = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let subst_model = SubstModel::<Q>::new(&[], &[]);
     for (i, &char) in chars.iter().enumerate() {
         assert!(pip_model.rate(char, char) < 0.0);
         assert_relative_eq!(pip_model.q.row(i).sum(), 0.0, epsilon = 1e-10);
@@ -237,8 +237,7 @@ fn pip_dna_tn93_correct() {
         &[0.22, 0.26, 0.33, 0.19],
         &[0.2, 0.5, 0.5970915, 0.2940435, 0.00135],
     );
-    let tn93 = SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435, 0.00135])
-        .unwrap();
+    let tn93 = SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435, 0.00135]);
     let mut diff = SubstMatrix::zeros(4, 4);
     diff.fill_diagonal(-0.5);
     diff = diff.insert_column(4, 0.5).insert_row(4, 0.0);

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -659,6 +659,12 @@ fn pip_likelihood_protein_example() {
 
 #[test]
 fn designation() {
+    let model = PIPModel::<JC69>::new(&[], &[]);
+    assert!(format!("{}", model).contains("PIP"));
+    assert!(format!("{}", model).contains("lambda = 1.5"));
+    assert!(format!("{}", model).contains("mu = 1.5"));
+    assert!(format!("{}", model).contains("JC69"));
+
     let model = PIPModel::<JC69>::new(&[], &[2.0, 1.0]);
     assert!(format!("{}", model).contains("PIP"));
     assert!(format!("{}", model).contains("lambda = 2.0"));
@@ -674,6 +680,8 @@ fn designation() {
 
     let model = PIPModel::<HKY>::new(&[], &[2.0, 5.0, 2.5]);
     assert!(format!("{}", model).contains("PIP"));
+    assert!(format!("{}", model).contains("lambda = 2.0"));
+    assert!(format!("{}", model).contains("mu = 5.0"));
     assert!(format!("{}", model).contains("HKY"));
     assert!(format!("{}", model).contains("kappa = 2.5"));
 
@@ -682,9 +690,8 @@ fn designation() {
     assert!(format!("{}", model).contains("lambda = 2.5"));
     assert!(format!("{}", model).contains("mu = 0.3"));
     assert!(format!("{}", model).contains("TN93"));
-    assert!(format!("{}", model).contains("2.5"));
-    assert!(format!("{}", model).contains("0.3"));
     assert!(format!("{}", model).contains("0.1"));
+    assert!(format!("{}", model).contains("1.0"));
 
     let model = PIPModel::<GTR>::new(&[], &[1.4, 1.7]);
     assert!(format!("{}", model).contains("GTR"));

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -25,7 +25,7 @@ const UNNORMALIZED_PIP_HKY_Q: [f64; 25] = [
 
 #[cfg(test)]
 fn compare_pip_subst_rates_template<Q: QMatrix + QMatrixMaker>(chars: &[u8]) {
-    let pip_model = PIPModel::<Q>::new(&[], &[0.1, 0.4]).unwrap();
+    let pip_model = PIPModel::<Q>::new(&[], &[0.1, 0.4]);
     let subst_model = SubstModel::<Q>::new(&[], &[]).unwrap();
     for (i, &char) in chars.iter().enumerate() {
         assert!(pip_model.rate(char, char) < 0.0);
@@ -47,7 +47,7 @@ fn compare_pip_subst_rates_template<Q: QMatrix + QMatrixMaker>(chars: &[u8]) {
 
 #[test]
 fn pip_dna_jc69_correct() {
-    let pip_jc69 = PIPModel::<JC69>::new(&[], &[0.1, 0.4]).unwrap();
+    let pip_jc69 = PIPModel::<JC69>::new(&[], &[0.1, 0.4]);
     assert_eq!(pip_jc69.lambda(), 0.1);
     assert_eq!(pip_jc69.mu(), 0.4);
     assert_eq!(
@@ -67,7 +67,7 @@ fn pip_dna_k80_correct() {
     let lambda = 0.3;
     let mu = 0.7;
     let kappa = 0.5;
-    let pip_k80 = PIPModel::<K80>::new(&[], &[lambda, mu, kappa]).unwrap();
+    let pip_k80 = PIPModel::<K80>::new(&[], &[lambda, mu, kappa]);
     assert_eq!(pip_k80.lambda(), lambda);
     assert_eq!(pip_k80.mu(), mu);
     assert_eq!(
@@ -89,7 +89,7 @@ fn pip_dna_hky_correct() {
     let mu = 0.7;
     let kappa = 0.5;
     let freqs = &[0.22, 0.26, 0.33, 0.19];
-    let pip_hky = PIPModel::<HKY>::new(freqs, &[lambda, mu, kappa]).unwrap();
+    let pip_hky = PIPModel::<HKY>::new(freqs, &[lambda, mu, kappa]);
     assert_eq!(pip_hky.lambda(), lambda);
     assert_eq!(pip_hky.mu(), mu);
     assert_eq!(pip_hky.freqs(), &frequencies!(freqs).insert_row(4, 0.0));
@@ -101,8 +101,8 @@ fn pip_dna_hky_as_k80() {
     let lambda = 0.3;
     let mu = 0.7;
     let kappa = 0.5;
-    let pip_k80 = PIPModel::<K80>::new(&[], &[lambda, mu, kappa]).unwrap();
-    let pip_hky = PIPModel::<HKY>::new(&[0.25; 4], &[lambda, mu, kappa]).unwrap();
+    let pip_k80 = PIPModel::<K80>::new(&[], &[lambda, mu, kappa]);
+    let pip_hky = PIPModel::<HKY>::new(&[0.25; 4], &[lambda, mu, kappa]);
     assert_eq!(pip_k80.lambda(), pip_hky.lambda());
     assert_eq!(pip_k80.mu(), pip_hky.mu());
     assert_eq!(pip_k80.freqs(), pip_hky.freqs());
@@ -117,8 +117,9 @@ fn pip_dna_hky_as_k80() {
 
 #[cfg(test)]
 fn pip_too_few_params_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
-    let result = PIPModel::<Q>::new(freqs, params);
-    assert!(result.is_err());
+    let model = PIPModel::<Q>::new(freqs, params);
+    assert_eq!(model.params().len(), 2);
+    assert_eq!(model.params(), &[0.2, 1.5]);
 }
 
 #[test]
@@ -159,7 +160,7 @@ fn pip_normalised_check_template<Q: QMatrix + QMatrixMaker>(
     freqs: &[f64],
     params: &[f64],
 ) {
-    let pip = PIPModel::<Q>::new(freqs, params).unwrap();
+    let pip = PIPModel::<Q>::new(freqs, params);
     assert_eq!(pip.lambda(), params[0]);
     assert_eq!(pip.mu(), params[1]);
     let stat_dist = frequencies!(freqs).insert_row(freqs.len(), 0.0);
@@ -194,7 +195,7 @@ fn pip_protein_normalised() {
 
 #[cfg(test)]
 fn pip_infinity_p_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
-    let model = PIPModel::<Q>::new(freqs, params).unwrap();
+    let model = PIPModel::<Q>::new(freqs, params);
     let p_inf = model.p(10000.0);
     assert_eq!(p_inf.shape(), model.q().shape());
     for row in p_inf.row_iter() {
@@ -231,8 +232,7 @@ fn pip_dna_tn93_correct() {
     let pip_tn93 = PIPModel::<TN93>::new(
         &[0.22, 0.26, 0.33, 0.19],
         &[0.2, 0.5, 0.5970915, 0.2940435, 0.00135],
-    )
-    .unwrap();
+    );
     let tn93 = SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435, 0.00135])
         .unwrap();
     let mut diff = SubstMatrix::zeros(4, 4);
@@ -250,7 +250,7 @@ fn pip_dna_tn93_correct() {
 fn pip_p_example_matrix() {
     // PIP matrix example from the PIP likelihood tutorial, rounded to 3 decimal values
     let epsilon = 1e-3;
-    let mut pip_hky = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]).unwrap();
+    let mut pip_hky = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]);
     pip_hky.q = SubstMatrix::from_column_slice(5, 5, &UNNORMALIZED_PIP_HKY_Q);
     let expected_p = SubstMatrix::from_row_slice(
         5,
@@ -316,7 +316,7 @@ fn assert_values<Q: QMatrix>(
 fn pip_hky_likelihood_example_leaf_values() {
     let info = setup_example_phylo_info();
     let tree = info.tree.clone();
-    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]).unwrap();
+    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]);
     model.q = SubstMatrix::from_column_slice(5, 5, &UNNORMALIZED_PIP_HKY_Q);
 
     let nu = 7.5;
@@ -363,7 +363,7 @@ fn pip_hky_likelihood_example_leaf_values() {
 #[test]
 fn pip_hky_likelihood_example_internals() {
     let info = setup_example_phylo_info();
-    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]).unwrap();
+    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]);
     model.q = SubstMatrix::from_column_slice(5, 5, &UNNORMALIZED_PIP_HKY_Q);
 
     let c = PIPB::new(model, info.clone()).build().unwrap();
@@ -423,7 +423,7 @@ fn assert_c0_values<Q: QMatrix>(tmp: &PIPModelInfo<Q>, idx: usize, exp_f1: f64, 
 #[test]
 fn pip_hky_likelihood_example_c0() {
     let info = setup_example_phylo_info();
-    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]).unwrap();
+    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]);
     model.q = SubstMatrix::from_column_slice(5, 5, &UNNORMALIZED_PIP_HKY_Q);
 
     let c = PIPB::new(model, info.clone()).build().unwrap();
@@ -478,7 +478,7 @@ fn pip_hky_likelihood_example_c0() {
 #[test]
 fn pip_hky_likelihood_example_final() {
     let info = setup_example_phylo_info();
-    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]).unwrap();
+    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]);
     model.q = SubstMatrix::from_column_slice(5, 5, &UNNORMALIZED_PIP_HKY_Q);
 
     let c = PIPB::new(model, info.clone()).build().unwrap();
@@ -518,7 +518,7 @@ fn setup_example_phylo_info_2() -> PhyloInfo {
 
 #[test]
 fn pip_hky_likelihood_example_2() {
-    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]).unwrap();
+    let mut model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]);
     model.q = SubstMatrix::from_column_slice(5, 5, &UNNORMALIZED_PIP_HKY_Q);
     let info = setup_example_phylo_info_2();
     let c = PIPB::new(model, info).build().unwrap();
@@ -533,7 +533,7 @@ fn pip_likelihood_huelsenbeck_example() {
     )
     .build()
     .unwrap();
-    let model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]).unwrap();
+    let model = PIPModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.25, 0.5]);
     let mut c = PIPB::new(model, info.clone()).build().unwrap();
     assert_relative_eq!(c.cost(), -372.1419415285655, epsilon = 1e-4);
 
@@ -548,8 +548,7 @@ fn pip_likelihood_huelsenbeck_example() {
     let model = PIPModel::<GTR>::new(
         &[0.22, 0.26, 0.33, 0.19],
         &[0.5, 0.25, 1.25453, 1.07461, 1.0, 1.14689, 1.53244, 1.47031],
-    )
-    .unwrap();
+    );
     let c = PIPB::new(model, info).build().unwrap();
 
     assert_relative_eq!(c.cost(), -359.2343309917135, epsilon = 1e-4);
@@ -564,10 +563,10 @@ fn pip_likelihood_huelsenbeck_example_model_comp() {
     .build()
     .unwrap();
 
-    let jc69 = PIPModel::<JC69>::new(&[], &[1.1, 0.55]).unwrap();
+    let jc69 = PIPModel::<JC69>::new(&[], &[1.1, 0.55]);
     let c = PIPB::new(jc69, info.clone()).build().unwrap();
 
-    let hky_as_jc = PIPModel::<HKY>::new(&[0.25, 0.25, 0.25, 0.25], &[1.1, 0.55, 1.0]).unwrap();
+    let hky_as_jc = PIPModel::<HKY>::new(&[0.25, 0.25, 0.25, 0.25], &[1.1, 0.55, 1.0]);
     let c_hky = PIPB::new(hky_as_jc, info.clone()).build().unwrap();
     assert_relative_eq!(c.cost(), c_hky.cost());
 }
@@ -583,8 +582,7 @@ fn pip_likelihood_huelsenbeck_example_reroot() {
     let model_gtr = PIPModel::<GTR>::new(
         &[0.22, 0.26, 0.33, 0.19],
         &[0.5, 0.25, 1.25453, 1.07461, 1.0, 1.14689, 1.53244, 1.47031],
-    )
-    .unwrap();
+    );
     let phylo_rerooted = PIB::with_attrs(
         PathBuf::from("./data/Huelsenbeck_example_long_DNA.fasta"),
         PathBuf::from("./data/Huelsenbeck_example_reroot.newick"),
@@ -607,25 +605,22 @@ fn pip_likelihood_protein_example() {
     .build()
     .unwrap();
 
-    let model_wag = PIPModel::<WAG>::new(&WAG_PI, &[0.5, 0.25]).unwrap();
+    let model_wag = PIPModel::<WAG>::new(&WAG_PI, &[0.5, 0.25]);
     let c = PIPB::new(model_wag, info.clone()).build().unwrap();
     assert!(c.cost() <= 0.0);
     // The cost is the same when initialising the model with default frequencies
     assert_eq!(
-        PIPB::new(
-            PIPModel::<WAG>::new(&[], &[0.5, 0.25]).unwrap(),
-            info.clone()
-        )
-        .build()
-        .unwrap()
-        .cost(),
+        PIPB::new(PIPModel::<WAG>::new(&[], &[0.5, 0.25]), info.clone())
+            .build()
+            .unwrap()
+            .cost(),
         c.cost(),
     );
 
     // The cost is different when initialising the model with equal frequencies
     assert_ne!(
         PIPB::new(
-            PIPModel::<WAG>::new(&[0.05; 20], &[0.5, 0.25]).unwrap(),
+            PIPModel::<WAG>::new(&[0.05; 20], &[0.5, 0.25]),
             info.clone()
         )
         .build()
@@ -636,58 +631,49 @@ fn pip_likelihood_protein_example() {
 
     // The cost is different when initialising the model with default frequencies but different mu/lambda
     assert_ne!(
-        PIPB::new(
-            PIPModel::<WAG>::new(&[], &[0.5, 0.2]).unwrap(),
-            info.clone()
-        )
-        .build()
-        .unwrap()
-        .cost(),
+        PIPB::new(PIPModel::<WAG>::new(&[], &[0.5, 0.2]), info.clone())
+            .build()
+            .unwrap()
+            .cost(),
         c.cost(),
     );
     assert_ne!(
-        PIPB::new(
-            PIPModel::<WAG>::new(&[], &[0.1, 0.25]).unwrap(),
-            info.clone()
-        )
-        .build()
-        .unwrap()
-        .cost(),
+        PIPB::new(PIPModel::<WAG>::new(&[], &[0.1, 0.25]), info.clone())
+            .build()
+            .unwrap()
+            .cost(),
         c.cost(),
     );
     assert_ne!(
-        PIPB::new(
-            PIPModel::<WAG>::new(&[], &[0.1, 0.2]).unwrap(),
-            info.clone()
-        )
-        .build()
-        .unwrap()
-        .cost(),
+        PIPB::new(PIPModel::<WAG>::new(&[], &[0.1, 0.2]), info.clone())
+            .build()
+            .unwrap()
+            .cost(),
         c.cost(),
     );
 }
 
 #[test]
 fn designation() {
-    let model = PIPModel::<JC69>::new(&[], &[2.0, 1.0]).unwrap();
+    let model = PIPModel::<JC69>::new(&[], &[2.0, 1.0]);
     assert!(format!("{}", model).contains("PIP"));
     assert!(format!("{}", model).contains("lambda = 2.0"));
     assert!(format!("{}", model).contains("mu = 1.0"));
     assert!(format!("{}", model).contains("JC69"));
 
-    let model = PIPModel::<K80>::new(&[], &[2.0, 5.0, 1.3]).unwrap();
+    let model = PIPModel::<K80>::new(&[], &[2.0, 5.0, 1.3]);
     assert!(format!("{}", model).contains("PIP"));
     assert!(format!("{}", model).contains("lambda = 2.0"));
     assert!(format!("{}", model).contains("mu = 5.0"));
     assert!(format!("{}", model).contains("K80"));
     assert!(format!("{}", model).contains("kappa = 1.3"));
 
-    let model = PIPModel::<HKY>::new(&[], &[2.0, 5.0, 2.5]).unwrap();
+    let model = PIPModel::<HKY>::new(&[], &[2.0, 5.0, 2.5]);
     assert!(format!("{}", model).contains("PIP"));
     assert!(format!("{}", model).contains("HKY"));
     assert!(format!("{}", model).contains("kappa = 2.5"));
 
-    let model = PIPModel::<TN93>::new(&[], &[2.5, 0.3, 0.1]).unwrap();
+    let model = PIPModel::<TN93>::new(&[], &[2.5, 0.3, 0.1]);
     assert!(format!("{}", model).contains("PIP"));
     assert!(format!("{}", model).contains("lambda = 2.5"));
     assert!(format!("{}", model).contains("mu = 0.3"));
@@ -696,18 +682,18 @@ fn designation() {
     assert!(format!("{}", model).contains("0.3"));
     assert!(format!("{}", model).contains("0.1"));
 
-    let model = PIPModel::<GTR>::new(&[], &[1.4, 1.7]).unwrap();
+    let model = PIPModel::<GTR>::new(&[], &[1.4, 1.7]);
     assert!(format!("{}", model).contains("GTR"));
 
-    let model = PIPModel::<WAG>::new(&[], &[2.0, 1.0]).unwrap();
+    let model = PIPModel::<WAG>::new(&[], &[2.0, 1.0]);
     assert!(format!("{}", model).contains("PIP"));
     assert!(format!("{}", model).contains("WAG"));
 
-    let model = PIPModel::<HIVB>::new(&[], &[2.0, 1.0]).unwrap();
+    let model = PIPModel::<HIVB>::new(&[], &[2.0, 1.0]);
     assert!(format!("{}", model).contains("PIP"));
     assert!(format!("{}", model).contains("HIVB"));
 
-    let model = PIPModel::<BLOSUM>::new(&[], &[2.0, 1.0]).unwrap();
+    let model = PIPModel::<BLOSUM>::new(&[], &[2.0, 1.0]);
     assert!(format!("{}", model).contains("PIP"));
     assert!(format!("{}", model).contains("BLOSUM"));
 }
@@ -725,7 +711,7 @@ fn pip_logl_correct_w_diff_info() {
     let info1 = PIB::build_from_objects(sequences.clone(), tree1).unwrap();
     let info2 = PIB::build_from_objects(sequences, tree2).unwrap();
 
-    let pip_wag = PIPModel::<WAG>::new(&[], &[50.0, 0.1]).unwrap();
+    let pip_wag = PIPModel::<WAG>::new(&[], &[50.0, 0.1]);
 
     let c1 = PIPB::new(pip_wag.clone(), info1).build().unwrap();
     let c2 = PIPB::new(pip_wag, info2).build().unwrap();
@@ -744,8 +730,7 @@ fn hiv_subset_valid_pip_likelihood() {
     let pip = PIPModel::<GTR>::new(
         &[0.25, 0.25, 0.25, 0.25],
         &[0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-    )
-    .unwrap();
+    );
     let c = PIPB::new(pip, info).build().unwrap();
     let logl = c.cost();
     assert_ne!(logl, f64::NEG_INFINITY);
@@ -755,7 +740,7 @@ fn hiv_subset_valid_pip_likelihood() {
 #[cfg(test)]
 fn avg_rate_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
     let mu = params[1];
-    let model = PIPModel::<Q>::new(freqs, params).unwrap();
+    let model = PIPModel::<Q>::new(freqs, params);
     let n = model.q().nrows();
     let avg_rate = model
         .q()
@@ -793,7 +778,7 @@ fn logl_not_inf_for_empty_col() {
         read_sequences_from_file(&PathBuf::from("./data/sequences_empty_col.fasta")).unwrap(),
     );
     let info = PIB::build_from_objects(sequences, tree).unwrap();
-    let model = PIPModel::<WAG>::new(&[], &[0.5, 0.5]).unwrap();
+    let model = PIPModel::<WAG>::new(&[], &[0.5, 0.5]);
     let c = PIPB::new(model, info).build().unwrap();
     let logl = c.cost();
     assert_ne!(logl, f64::NEG_INFINITY);

--- a/phylo/src/substitution_models/mod.rs
+++ b/phylo/src/substitution_models/mod.rs
@@ -61,13 +61,13 @@ impl<Q: QMatrix + Display> Display for SubstModel<Q> {
 }
 
 impl<Q: QMatrix + QMatrixMaker> SubstModel<Q> {
-    pub fn new(frequencies: &[f64], params: &[f64]) -> Result<Self>
+    pub fn new(frequencies: &[f64], params: &[f64]) -> Self
     where
         Self: Sized,
     {
-        Ok(SubstModel {
+        SubstModel {
             qmatrix: Q::create(frequencies, params),
-        })
+        }
     }
 }
 

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -24,7 +24,7 @@ use crate::{frequencies, record_wo_desc as record, tree};
 #[cfg(test)]
 fn freqs_fixed_template<Q: QMatrix + QMatrixMaker>(params: &[f64]) {
     // freqs should not change for JC69 and K80
-    let mut model = SubstModel::<Q>::new(&[], params).unwrap();
+    let mut model = SubstModel::<Q>::new(&[], params);
     model.set_freqs(frequencies!(&[0.1, 0.2, 0.3, 0.4]));
     assert_eq!(model.freqs(), &frequencies!(&[0.25; 4]));
 }
@@ -38,7 +38,7 @@ fn dna_freqs_fixed() {
 #[cfg(test)]
 fn freqs_updated_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
     // freqs should change for HKY, TN93, and GTR
-    let mut model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let mut model = SubstModel::<Q>::new(freqs, params);
     let new_freqs = frequencies!(&[0.1, 0.2, 0.3, 0.4]);
     model.set_freqs(new_freqs.clone());
     assert_eq!(model.freqs(), &new_freqs);
@@ -55,8 +55,7 @@ fn dna_freqs_updated() {
 #[cfg(test)]
 fn param_fixed_template<Q: QMatrix + QMatrixMaker>(params: &[f64]) {
     // parameters should not change for JC69
-    let model = SubstModel::<Q>::new(&[], params).unwrap();
-    assert!(model.params().is_empty());
+    let model = SubstModel::<Q>::new(&[], params);
     let mut updated_model = model.clone();
     updated_model.set_param(0, 66.0);
     assert_eq!(model.params(), updated_model.params());
@@ -71,7 +70,7 @@ fn dna_params_fixed() {
 #[cfg(test)]
 fn params_updated_template<Q: QMatrix + QMatrixMaker>(params: &[f64], new_params: &[f64]) {
     // parameters should change for K80, HKY, TN93, and GTR
-    let mut model = SubstModel::<Q>::new(&[], params).unwrap();
+    let mut model = SubstModel::<Q>::new(&[], params);
     for (i, &param) in new_params.iter().enumerate() {
         model.set_param(i, param);
     }
@@ -97,31 +96,31 @@ fn check_freq_convergence(substmat: SubstMatrix, pi: &FreqVector, epsilon: f64) 
 
 #[test]
 fn dna_jc69_correct() {
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
-    let jc69_2 = SubstModel::<JC69>::new(&[], &[1.0, 2.0]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
+    let jc69_2 = SubstModel::<JC69>::new(&[], &[1.0, 2.0]);
     assert_eq!(jc69, jc69_2);
     assert_relative_eq!(jc69.rate(b'A', b'A'), -1.0);
     assert_relative_eq!(jc69.rate(b'A', b'C'), 1.0 / 3.0);
     assert_relative_eq!(jc69.rate(b'G', b'T'), 1.0 / 3.0);
     assert_relative_eq!(jc69.freqs(), &frequencies!(&[0.25, 0.25, 0.25, 0.25]));
-    let jc69_3 = SubstModel::<JC69>::new(&[], &[4.0]).unwrap();
+    let jc69_3 = SubstModel::<JC69>::new(&[], &[4.0]);
     assert_eq!(jc69.q(), jc69_3.q());
     assert_eq!(jc69.freqs(), jc69_3.freqs());
 }
 
 #[test]
 fn dna_j69_params() {
-    let jc69 = SubstModel::<JC69>::new(&[0.1, 0.4, 0.75, 1.5], &[0.1, 0.4, 0.75, 1.5]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[0.1, 0.4, 0.75, 1.5], &[0.1, 0.4, 0.75, 1.5]);
     assert_relative_eq!(jc69.freqs(), &frequencies!(&[0.25, 0.25, 0.25, 0.25]));
     assert_eq!(format!("{}", jc69), format!("JC69"));
 }
 
 #[test]
 fn dna_k80_correct() {
-    let k80 = SubstModel::<K80>::new(&[], &[]).unwrap();
-    let k801 = SubstModel::<K80>::new(&[], &[2.0]).unwrap();
-    let k802 = SubstModel::<K80>::new(&[], &[2.0, 1.0]).unwrap();
-    let k803 = SubstModel::<K80>::new(&[], &[2.0, 1.0, 3.0, 6.0]).unwrap();
+    let k80 = SubstModel::<K80>::new(&[], &[]);
+    let k801 = SubstModel::<K80>::new(&[], &[2.0]);
+    let k802 = SubstModel::<K80>::new(&[], &[2.0, 1.0]);
+    let k803 = SubstModel::<K80>::new(&[], &[2.0, 1.0, 3.0, 6.0]);
     assert_eq!(k80, k801);
     assert_eq!(k80, k802);
     assert_eq!(k80, k803);
@@ -134,7 +133,7 @@ fn dna_k80_correct() {
 
 #[cfg(test)]
 fn infinity_p_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
-    let model: SubstModel<Q> = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model: SubstModel<Q> = SubstModel::<Q>::new(freqs, params);
     let p_inf = model.p(1000.0);
     assert_eq!(p_inf.shape(), model.q().shape());
     check_freq_convergence(p_inf, model.freqs(), 1e-5);
@@ -158,33 +157,33 @@ fn protein_infinity_p() {
 
 #[test]
 fn dna_k80_params() {
-    let k80 = SubstModel::<K80>::new(&[0.1, 0.4, 0.75, 1.5], &[0.1, 0.4, 0.75, 1.5]).unwrap();
+    let k80 = SubstModel::<K80>::new(&[0.1, 0.4, 0.75, 1.5], &[0.1, 0.4, 0.75, 1.5]);
     assert_relative_eq!(k80.freqs(), &frequencies!(&[0.25, 0.25, 0.25, 0.25]));
     assert_eq!(format!("{}", k80), format!("K80 with [kappa = {:.5}]", 0.1));
 }
 
 #[test]
 fn dna_hky_incorrect() {
-    let hky = SubstModel::<HKY>::new(&[2.0, 1.0, 3.0, 6.0], &[]).unwrap();
+    let hky = SubstModel::<HKY>::new(&[2.0, 1.0, 3.0, 6.0], &[]);
     assert_eq!(hky.freqs(), &frequencies!(&[0.25, 0.25, 0.25, 0.25]));
     assert_eq!(hky.params(), &[2.0]);
-    let hky = SubstModel::<HKY>::new(&[2.0, 1.0, 3.0, 6.0], &[0.5]).unwrap();
+    let hky = SubstModel::<HKY>::new(&[2.0, 1.0, 3.0, 6.0], &[0.5]);
     assert_eq!(hky.freqs(), &frequencies!(&[0.25, 0.25, 0.25, 0.25]));
     assert_eq!(hky.params(), &[0.5]);
-    let hky = SubstModel::<HKY>::new(&[2.0, 1.0, 3.0, 6.0], &[0.5, 1.0]).unwrap();
+    let hky = SubstModel::<HKY>::new(&[2.0, 1.0, 3.0, 6.0], &[0.5, 1.0]);
     assert_eq!(hky.freqs(), &frequencies!(&[0.25, 0.25, 0.25, 0.25]));
     assert_eq!(hky.params(), &[0.5]);
 }
 
 #[test]
 fn dna_hky_correct() {
-    let hky = SubstModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5]).unwrap();
+    let hky = SubstModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5]);
     assert_relative_eq!(hky.freqs(), &dvector![0.22, 0.26, 0.33, 0.19]);
-    let hky2 = SubstModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 1.0]).unwrap();
+    let hky2 = SubstModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 1.0]);
     assert_relative_eq!(hky2.freqs(), &dvector![0.22, 0.26, 0.33, 0.19]);
     assert_eq!(hky, hky2);
-    let hky3 = SubstModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[]).unwrap();
-    let hky4 = SubstModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[2.0, 1.0]).unwrap();
+    let hky3 = SubstModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[]);
+    let hky4 = SubstModel::<HKY>::new(&[0.22, 0.26, 0.33, 0.19], &[2.0, 1.0]);
     assert_relative_eq!(
         hky3.q()
             .diagonal()
@@ -200,11 +199,10 @@ fn dna_gtr_equal_rates_correct() {
     let gtr = SubstModel::<GTR>::new(
         &repeat(0.25).take(4).collect::<Vec<f64>>(),
         &repeat(1.0).take(5).collect::<Vec<f64>>(),
-    )
-    .unwrap();
+    );
     assert_eq!(gtr.freqs(), &frequencies!(&[0.25, 0.25, 0.25, 0.25]));
     assert_eq!(gtr.q()[(0, 0)], -1.0);
-    let gtr2 = SubstModel::<GTR>::new(&[], &repeat(1.0).take(5).collect::<Vec<f64>>()).unwrap();
+    let gtr2 = SubstModel::<GTR>::new(&[], &repeat(1.0).take(5).collect::<Vec<f64>>());
     assert_relative_eq!(gtr.q(), gtr2.q());
     assert!(gtr.rate(b'T', b'T') < 0.0);
     assert!(gtr.rate(b'A', b'A') < 0.0);
@@ -215,23 +213,22 @@ fn dna_gtr_equal_rates_correct() {
 
 #[test]
 fn dna_gtr_defaults() {
-    let gtr_no_freqs = SubstModel::<GTR>::new(&[], &[2.0, 1.0, 3.0, 6.0, 0.5]).unwrap();
+    let gtr_no_freqs = SubstModel::<GTR>::new(&[], &[2.0, 1.0, 3.0, 6.0, 0.5]);
     assert_relative_eq!(gtr_no_freqs.freqs(), &frequencies!(&[0.25; 4]));
     assert_eq!(gtr_no_freqs.params(), &[2.0, 1.0, 3.0, 6.0, 0.5]);
 
-    let gtr_missing_params =
-        SubstModel::<GTR>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.6, 0.7]).unwrap();
+    let gtr_missing_params = SubstModel::<GTR>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.6, 0.7]);
     assert_relative_eq!(
         gtr_missing_params.freqs(),
         &frequencies!(&[0.22, 0.26, 0.33, 0.19])
     );
     assert_eq!(gtr_missing_params.params(), &[0.5, 0.6, 0.7, 1.0, 1.0]);
 
-    let gtr_incorrect_freqs = SubstModel::<GTR>::new(&[0.3; 4], &[0.5; 5]).unwrap();
+    let gtr_incorrect_freqs = SubstModel::<GTR>::new(&[0.3; 4], &[0.5; 5]);
     assert_relative_eq!(gtr_incorrect_freqs.freqs(), &frequencies!(&[0.25; 4]));
     assert_eq!(gtr_incorrect_freqs.params(), &[0.5; 5]);
 
-    let gtr_too_many_params = SubstModel::<GTR>::new(&[0.22, 0.26, 0.33, 0.19], &[0.7; 6]).unwrap();
+    let gtr_too_many_params = SubstModel::<GTR>::new(&[0.22, 0.26, 0.33, 0.19], &[0.7; 6]);
     assert_relative_eq!(
         gtr_too_many_params.freqs(),
         &frequencies!(&[0.22, 0.26, 0.33, 0.19])
@@ -241,8 +238,7 @@ fn dna_gtr_defaults() {
 
 #[test]
 fn dna_tn93_correct() {
-    let tn93 = SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435, 0.00135])
-        .unwrap();
+    let tn93 = SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435, 0.00135]);
     let expected_pi = frequencies!(&[0.22, 0.26, 0.33, 0.19]);
     let expected_q = SubstMatrix::from_column_slice(
         4,
@@ -290,46 +286,45 @@ fn dna_tn93_correct() {
 #[test]
 fn dna_tn93_incorrect() {
     let tn93_too_few_params =
-        SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435]).unwrap();
+        SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435]);
     assert_relative_eq!(
         tn93_too_few_params.freqs(),
         &frequencies!(&[0.22, 0.26, 0.33, 0.19])
     );
     assert_eq!(tn93_too_few_params.params(), &[0.5970915, 0.2940435, 1.0]);
 
-    let tn93_incorrect_freqs =
-        SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 1.19], &[0.5, 0.6, 0.3]).unwrap();
+    let tn93_incorrect_freqs = SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 1.19], &[0.5, 0.6, 0.3]);
     assert_relative_eq!(tn93_incorrect_freqs.freqs(), &frequencies!(&[0.25; 4]));
     assert_eq!(tn93_incorrect_freqs.params(), &[0.5, 0.6, 0.3]);
 
     let tn93_too_many_params =
-        SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.6, 0.3, 0.56]).unwrap();
+        SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5, 0.6, 0.3, 0.56]);
     assert_relative_eq!(
         tn93_too_many_params.freqs(),
         &frequencies!(&[0.22, 0.26, 0.33, 0.19])
     );
     assert_eq!(tn93_too_many_params.params(), &[0.5, 0.6, 0.3]);
 
-    let tn93_no_freqs = SubstModel::<TN93>::new(&[], &[2.0, 1.0, 3.0]).unwrap();
+    let tn93_no_freqs = SubstModel::<TN93>::new(&[], &[2.0, 1.0, 3.0]);
     assert_relative_eq!(tn93_no_freqs.freqs(), &frequencies!(&[0.25; 4]));
     assert_eq!(tn93_no_freqs.params(), &[2.0, 1.0, 3.0]);
 }
 
 #[test]
 fn dna_normalisation() {
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     assert_relative_eq!(jc69.q().diagonal().component_mul(jc69.freqs()).sum(), -1.0);
-    let k80 = SubstModel::<K80>::new(&[], &[3.0, 1.5]).unwrap();
+    let k80 = SubstModel::<K80>::new(&[], &[3.0, 1.5]);
     assert_relative_eq!(k80.q().diagonal().component_mul(k80.freqs()).sum(), -1.0);
-    let gtr = SubstModel::<GTR>::new(&[0.22, 0.26, 0.33, 0.19], &[0.7; 5]).unwrap();
+    let gtr = SubstModel::<GTR>::new(&[0.22, 0.26, 0.33, 0.19], &[0.7; 5]);
     assert_relative_eq!(gtr.q().diagonal().component_mul(gtr.freqs()).sum(), -1.0);
-    let tn93 = SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.59, 0.29, 0.0013]).unwrap();
+    let tn93 = SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.59, 0.29, 0.0013]);
     assert_relative_eq!(tn93.q().diagonal().component_mul(tn93.freqs()).sum(), -1.0);
 }
 
 #[test]
 fn dna_normalised_param_change() {
-    let mut k80 = SubstModel::<K80>::new(&[], &[3.0]).unwrap();
+    let mut k80 = SubstModel::<K80>::new(&[], &[3.0]);
     assert_eq!(k80.q().diagonal().component_mul(k80.freqs()).sum(), -1.0);
     let k80_old = k80.clone();
     assert_eq!(k80.params(), &[3.0]);
@@ -343,8 +338,8 @@ fn dna_normalised_param_change() {
 
 #[cfg(test)]
 fn protein_correct_access_template<Q: QMatrix + QMatrixMaker>(epsilon: f64) {
-    let model_1 = SubstModel::<Q>::new(&[], &[]).unwrap();
-    let model_2 = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let model_1 = SubstModel::<Q>::new(&[], &[]);
+    let model_2 = SubstModel::<Q>::new(&[], &[]);
     assert_relative_eq!(model_1.q(), model_2.q());
     for _ in 0..10 {
         let mut rng = rand::thread_rng();
@@ -364,7 +359,7 @@ fn protein_correct_access() {
 
 #[cfg(test)]
 fn protein_gap_access_template<Q: QMatrix + QMatrixMaker>() {
-    let model = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let model = SubstModel::<Q>::new(&[], &[]);
     model.rate(GAP, b'L');
 }
 
@@ -388,7 +383,7 @@ fn protein_incorrect_access_blosum() {
 
 #[cfg(test)]
 fn normalised_template<Q: QMatrix + QMatrixMaker>() {
-    let model = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let model = SubstModel::<Q>::new(&[], &[]);
     assert_relative_eq!(
         (model.q().diagonal().transpose().mul(model.freqs()))[(0, 0)],
         -1.0,
@@ -419,7 +414,7 @@ fn dna_scoring_matrices_template<Q: QMatrix + QMatrixMaker>(
     times: &[f64],
     rounding: &R,
 ) {
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let scorings = ParsimonyModel::generate_scorings(&model, times, false, rounding);
     for &time in times {
         let (_, avg_0) = ParsimonyModel::scoring_matrix(&model, time, rounding);
@@ -479,7 +474,7 @@ const TRUE_MATRIX: [f64; 400] = [
 
 #[test]
 fn protein_scoring_matrices() {
-    let model = SubstModel::<WAG>::new(&[], &[]).unwrap();
+    let model = SubstModel::<WAG>::new(&[], &[]);
     let true_matrix_01 = SubstMatrix::from_row_slice(20, 20, &TRUE_MATRIX);
     let (mat, avg) = ParsimonyModel::scoring_matrix(&model, 0.1, &R::zero());
 
@@ -496,7 +491,7 @@ fn protein_scoring_matrices() {
 
 #[test]
 fn generate_protein_scorings() {
-    let model = SubstModel::<WAG>::new(&[], &[]).unwrap();
+    let model = SubstModel::<WAG>::new(&[], &[]);
     let scorings =
         ParsimonyModel::generate_scorings(&model, &[0.1, 0.3, 0.5, 0.7], false, &R::zero());
     let true_matrix_01 = SubstMatrix::from_row_slice(20, 20, &TRUE_MATRIX);
@@ -515,7 +510,7 @@ fn generate_protein_scorings() {
 
 #[test]
 fn matrix_entry_rounding() {
-    let model = SubstModel::<K80>::new(&[], &[1.0, 2.0]).unwrap();
+    let model = SubstModel::<K80>::new(&[], &[1.0, 2.0]);
     let (mat_round, avg_round) = model.scoring_matrix_corrected(0.1, true, &R::zero());
     let (mat, avg) = model.scoring_matrix_corrected(0.1, true, &R::none());
     assert_ne!(avg_round, avg);
@@ -523,7 +518,7 @@ fn matrix_entry_rounding() {
     for &element in mat_round.as_slice() {
         assert_eq!(element.round(), element);
     }
-    let model = SubstModel::<HIVB>::new(&[], &[]).unwrap();
+    let model = SubstModel::<HIVB>::new(&[], &[]);
     let (mat_round, avg_round) = model.scoring_matrix_corrected(0.1, true, &R::zero());
     let (mat, avg) = model.scoring_matrix_corrected(0.1, true, &R::none());
     assert_ne!(avg_round, avg);
@@ -535,7 +530,7 @@ fn matrix_entry_rounding() {
 
 #[test]
 fn matrix_zero_diagonals() {
-    let model = SubstModel::<HIVB>::new(&[], &[]).unwrap();
+    let model = SubstModel::<HIVB>::new(&[], &[]);
     let (mat_zeros, avg_zeros) = model.scoring_matrix_corrected(0.5, true, &R::zero());
     let (mat, avg) = model.scoring_matrix_corrected(0.5, false, &R::zero());
     assert_ne!(avg_zeros, avg);
@@ -548,22 +543,19 @@ fn matrix_zero_diagonals() {
 
 #[test]
 fn designation() {
-    let jc69_model_desc = format!("{}", SubstModel::<JC69>::new(&[], &[2.0]).unwrap());
+    let jc69_model_desc = format!("{}", SubstModel::<JC69>::new(&[], &[2.0]));
     assert!(jc69_model_desc.contains("JC69"));
     assert!(!jc69_model_desc.contains("2.0"));
 
-    let k80_model_desc = format!("{}", SubstModel::<K80>::new(&[], &[2.0]).unwrap());
+    let k80_model_desc = format!("{}", SubstModel::<K80>::new(&[], &[2.0]));
     assert!(k80_model_desc.contains("K80"));
     assert!(k80_model_desc.contains("kappa = 2.0"));
 
-    let hky_model_desc = format!("{}", SubstModel::<HKY>::new(&[], &[2.5]).unwrap());
+    let hky_model_desc = format!("{}", SubstModel::<HKY>::new(&[], &[2.5]));
     assert!(hky_model_desc.contains("HKY"));
     assert!(hky_model_desc.contains("kappa = 2.5"));
 
-    let tn93_model_desc = format!(
-        "{}",
-        SubstModel::<TN93>::new(&[], &[2.5, 0.3, 0.1]).unwrap()
-    );
+    let tn93_model_desc = format!("{}", SubstModel::<TN93>::new(&[], &[2.5, 0.3, 0.1]));
     assert!(tn93_model_desc.contains("TN93"));
     assert!(tn93_model_desc.contains("2.5"));
     assert!(tn93_model_desc.contains("0.3"));
@@ -571,7 +563,7 @@ fn designation() {
 
     let gtr_model_desc = format!(
         "{}",
-        SubstModel::<GTR>::new(&[0.22, 0.26, 0.33, 0.19], &[1.5, 3.0, 1.25, 0.45, 0.1]).unwrap()
+        SubstModel::<GTR>::new(&[0.22, 0.26, 0.33, 0.19], &[1.5, 3.0, 1.25, 0.45, 0.1])
     );
     assert!(gtr_model_desc.contains("GTR"));
     assert!(gtr_model_desc.contains("rtc = 1.5"));
@@ -585,13 +577,13 @@ fn designation() {
     assert!(gtr_model_desc.contains("0.33"));
     assert!(gtr_model_desc.contains("0.19"));
 
-    let wag_model_desc = format!("{}", SubstModel::<WAG>::new(&[], &[]).unwrap());
+    let wag_model_desc = format!("{}", SubstModel::<WAG>::new(&[], &[]));
     assert!(wag_model_desc.contains("WAG"));
 
-    let hivb_model_desc = format!("{}", SubstModel::<HIVB>::new(&[], &[]).unwrap());
+    let hivb_model_desc = format!("{}", SubstModel::<HIVB>::new(&[], &[]));
     assert!(hivb_model_desc.contains("HIVB"));
 
-    let blosum_model_desc = format!("{}", SubstModel::<BLOSUM>::new(&[], &[]).unwrap());
+    let blosum_model_desc = format!("{}", SubstModel::<BLOSUM>::new(&[], &[]));
     assert!(blosum_model_desc.contains("BLOSUM"));
 }
 
@@ -605,12 +597,12 @@ fn setup_simple_phylo_info(blen_i: f64, blen_j: f64) -> PhyloInfo {
 #[test]
 fn dna_simple_likelihood() {
     let info = setup_simple_phylo_info(1.0, 1.0);
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let c = SCB::new(jc69, info).build().unwrap();
     assert_relative_eq!(c.cost(), -2.5832498829317445, epsilon = 1e-6);
 
     let info = setup_simple_phylo_info(1.0, 2.0);
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let c = SCB::new(jc69, info).build().unwrap();
     assert_relative_eq!(c.cost(), -2.719098272533848, epsilon = 1e-6);
 }
@@ -631,7 +623,7 @@ fn setup_cb_example_phylo_info() -> PhyloInfo {
 fn change_logl_on_freq_change_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
     // likelihood should change when frequencies are changed in models with free freqs
     let info = setup_cb_example_phylo_info();
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let mut c = SCB::new(model, info).build().unwrap();
 
     let logl = c.cost();
@@ -650,7 +642,7 @@ fn change_logl_on_freq_change() {
 fn same_logl_on_freq_change_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
     // likelihood should change when frequencies are changed in models with free freqs
     let info = setup_cb_example_phylo_info();
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let mut c = SCB::new(model, info).build().unwrap();
     let logl = c.cost();
     c.set_freqs(frequencies!(&[0.1, 0.2, 0.3, 0.4]));
@@ -667,7 +659,7 @@ fn same_logl_on_freq_change() {
 fn change_logl_on_param_change_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
     // likelihood should change when frequencies are changed in models with free freqs
     let info = setup_cb_example_phylo_info();
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let mut c = SCB::new(model, info).build().unwrap();
     let logl = c.cost();
     c.set_param(0, 100.0);
@@ -692,7 +684,7 @@ fn change_logl_on_param_change() {
 fn same_likelihood_on_param_change() {
     // likelihood should not change when parameters are changed for jc69
     let info = setup_cb_example_phylo_info();
-    let model = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let model = SubstModel::<JC69>::new(&[], &[]);
     let mut c = SCB::new(model, info).build().unwrap();
     let logl = c.cost();
     c.set_param(0, 100.0);
@@ -717,7 +709,7 @@ fn dna_gaps_as_ambigs_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params:
     ]);
     let info_gaps = PIB::build_from_objects(sequences, tree.clone()).unwrap();
 
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let c_ambig = SCB::new(model.clone(), info_ambig).build().unwrap();
     let c_gaps = SCB::new(model, info_gaps).build().unwrap();
     assert_eq!(c_ambig.cost(), c_gaps.cost());
@@ -745,7 +737,7 @@ fn setup_phylo_info_single_leaf() -> PhyloInfo {
 #[cfg(test)]
 fn dna_likelihood_one_node_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
     let info = setup_phylo_info_single_leaf();
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let c = SCB::new(model, info).build().unwrap();
     assert!(c.cost() < 0.0);
 }
@@ -766,8 +758,7 @@ fn dna_likelihood_one_node() {
 fn dna_cb_example_likelihood() {
     let info = setup_cb_example_phylo_info();
     let mut model =
-        SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435, 0.00135])
-            .unwrap();
+        SubstModel::<TN93>::new(&[0.22, 0.26, 0.33, 0.19], &[0.5970915, 0.2940435, 0.00135]);
     model.qmatrix.q = SubstMatrix::from_row_slice(
         4,
         4,
@@ -810,7 +801,7 @@ fn setup_mol_evo_example_phylo_info() -> PhyloInfo {
 #[test]
 fn dna_mol_evo_example_likelihood() {
     let info = setup_mol_evo_example_phylo_info();
-    let model = SubstModel::<K80>::new(&[], &[]).unwrap();
+    let model = SubstModel::<K80>::new(&[], &[]);
     let c = SCB::new(model, info).build().unwrap();
     assert_relative_eq!(c.cost(), -7.581408, epsilon = 1e-6);
 }
@@ -833,7 +824,7 @@ fn dna_ambig_example_logl_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], par
     .build()
     .unwrap();
 
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let c_w_x = SCB::new(model.clone(), info_w_x).build().unwrap();
     let c_w_n = SCB::new(model, info_w_n).build().unwrap();
 
@@ -862,7 +853,7 @@ fn dna_ambig_example_likelihood_k80() {
     )
     .build()
     .unwrap();
-    let k80 = SubstModel::<K80>::new(&[], &[2.0, 1.0]).unwrap();
+    let k80 = SubstModel::<K80>::new(&[], &[2.0, 1.0]);
     let c = SCB::new(k80, info_w_x).build().unwrap();
     assert_relative_eq!(c.cost(), -137.24280493914029, epsilon = 1e-6);
 }
@@ -877,11 +868,10 @@ fn dna_huelsenbeck_example_likelihood() {
     )
     .build()
     .unwrap();
-    let hky = SubstModel::<HKY>::new(&[0.1, 0.3, 0.4, 0.2], &[5.0]).unwrap();
+    let hky = SubstModel::<HKY>::new(&[0.1, 0.3, 0.4, 0.2], &[5.0]);
     let c = SCB::new(hky, info.clone()).build().unwrap();
     assert_relative_eq!(c.cost(), -216.234734, epsilon = 1e-3);
-    let gtr_as_hky =
-        SubstModel::<GTR>::new(&[0.1, 0.3, 0.4, 0.2], &[5.0, 1.0, 1.0, 1.0, 1.0, 5.0]).unwrap();
+    let gtr_as_hky = SubstModel::<GTR>::new(&[0.1, 0.3, 0.4, 0.2], &[5.0, 1.0, 1.0, 1.0, 1.0, 5.0]);
     let c_gtr = SCB::new(gtr_as_hky, info).build().unwrap();
     assert_relative_eq!(c_gtr.cost(), -216.234734, epsilon = 1e-3);
 }
@@ -896,7 +886,7 @@ fn protein_example_logl_template<Q: QMatrix + QMatrixMaker>(
     let info = PIB::with_attrs(fldr.join("nogap_seqs.fasta"), fldr.join("true_tree.newick"))
         .build()
         .unwrap();
-    let model = SubstModel::<Q>::new(&[], params).unwrap();
+    let model = SubstModel::<Q>::new(&[], params);
     let c = SCB::new(model, info).build().unwrap();
     assert_relative_eq!(c.cost(), expected_llik, epsilon = epsilon);
 }
@@ -927,7 +917,7 @@ fn simple_reroot_info(alphabet: &Alphabet) -> (PhyloInfo, PhyloInfo) {
 
 #[cfg(test)]
 fn logl_revers_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64], epsilon: f64) {
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let (info, info_rerooted) = simple_reroot_info(model.qmatrix.alphabet());
 
     let c = SCB::new(model.clone(), info).build().unwrap();
@@ -974,7 +964,7 @@ fn huelsenbeck_reversibility_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], 
     )
     .build()
     .unwrap();
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let c = SCB::new(model.clone(), info).build().unwrap();
     let c_rerooted = SCB::new(model, info_rerooted).build().unwrap();
     assert_relative_eq!(c.cost(), c_rerooted.cost(), epsilon = 1e-10,);
@@ -1008,7 +998,7 @@ fn logl_correct_w_diff_info<Q: QMatrix + QMatrixMaker>(llik1: f64, llik2: f64) {
     let info1 = PIB::build_from_objects(sequences.clone(), tree1).unwrap();
     let info2 = PIB::build_from_objects(sequences, tree2).unwrap();
 
-    let model = SubstModel::<Q>::new(&[], &[]).unwrap();
+    let model = SubstModel::<Q>::new(&[], &[]);
     let c1 = SCB::new(model.clone(), info1).build().unwrap();
     let c2 = SCB::new(model, info2).build().unwrap();
 
@@ -1025,7 +1015,7 @@ fn protein_logl_correct_w_diff_info() {
 
 fn one_site_one_char_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
     // This used to fail on leaf data creation when some of the sequences were empty
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let sequences = Sequences::with_alphabet(
         vec![
             record!("one", b"C"),
@@ -1065,8 +1055,7 @@ fn hiv_subset_valid_subst_likelihood() {
     let fldr = Path::new("./data/real_examples/");
     let alignment = fldr.join("HIV-1_env_DNA_mafft_alignment_subset.fasta");
     let info = PIB::new(alignment).build().unwrap();
-    let gtr =
-        SubstModel::<GTR>::new(&[0.25, 0.25, 0.25, 0.25], &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0]).unwrap();
+    let gtr = SubstModel::<GTR>::new(&[0.25, 0.25, 0.25, 0.25], &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0]);
     let c = SCB::new(gtr, info).build().unwrap();
     let logl = c.cost();
     assert_ne!(logl, f64::NEG_INFINITY);
@@ -1081,7 +1070,7 @@ fn dna_gaps_against_phyml() {
         read_sequences_from_file(&Path::new("./data/").join("sequences_DNA1.fasta")).unwrap(),
     );
     let info = PIB::build_from_objects(sequences, tree!(&newick)).unwrap();
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let c = SCB::new(jc69, info).build().unwrap();
 
     // Compare against value from PhyML
@@ -1090,7 +1079,7 @@ fn dna_gaps_against_phyml() {
 
 #[test]
 fn dna_single_char_gaps_against_phyml() {
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let tree =
         tree!("(C:0.06465432,D:27.43128366,(A:0.00000001,B:0.00000001)0.000000:0.08716381);");
 
@@ -1148,7 +1137,7 @@ fn dna_single_char_gaps_against_phyml() {
 
 #[test]
 fn dna_ambig_chars_against_phyml() {
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let tree = tree!("(C:0.06465432,D:27.43128366,(A:0.00000001,B:0.00000001)0.0:0.08716381);");
     let sequences = Sequences::new(vec![
         record!("A", b"B"),
@@ -1163,7 +1152,7 @@ fn dna_ambig_chars_against_phyml() {
 
 #[test]
 fn dna_x_simple_fully_likely() {
-    let jc69 = SubstModel::<JC69>::new(&[], &[]).unwrap();
+    let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let tree = tree!("(A:0.05,B:0.0005):0.0;");
     let sequences = Sequences::new(vec![record!("A", b"X"), record!("B", b"X")]);
     let info = PIB::build_from_objects(sequences, tree).unwrap();
@@ -1173,7 +1162,7 @@ fn dna_x_simple_fully_likely() {
 
 #[cfg(test)]
 fn x_fully_likely_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let tree = tree!("(((A:2.0,B:2.0)E:4.0,(C:2.0,D:2.0)F:4.0)G:6.0);");
     let sequences = Sequences::with_alphabet(
         vec![
@@ -1207,7 +1196,7 @@ fn protein_x_fully_likely() {
 
 #[cfg(test)]
 fn avg_rate_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) {
-    let model = SubstModel::<Q>::new(freqs, params).unwrap();
+    let model = SubstModel::<Q>::new(freqs, params);
     let avg_rate = model.q().diagonal().component_mul(model.freqs()).sum();
     assert_relative_eq!(avg_rate, -1.0, epsilon = 1e-10);
 }


### PR DESCRIPTION
Fixing the PIP model creation to not require parameter values as inputs but setting to defaults in case not enough values are provided.