### PR TITLE
Fix/substitution lik crash

### DIFF
--- a/phylo/src/lib.rs
+++ b/phylo/src/lib.rs
@@ -20,6 +20,8 @@ type Result<T> = std::result::Result<T, Error>;
 #[allow(non_camel_case_types)]
 type f64_h = ordered_float::OrderedFloat<f64>;
 
+pub(crate) const MAX_BLEN: f64 = 1e5f64;
+
 pub struct Rounding {
     pub round: bool,
     pub digits: usize,

--- a/phylo/src/optimisers/blen_optimiser.rs
+++ b/phylo/src/optimisers/blen_optimiser.rs
@@ -80,7 +80,7 @@ impl<C: TreeSearchCost + Clone + Display> BranchOptimiser<C> {
         let (min, max) = if start_blen == 0.0 {
             (0.0, 1.0)
         } else {
-            (start_blen * 0.1, start_blen * 10.0)
+            (start_blen * 0.1, 1e5f64.min(start_blen * 10.0))
         };
         let optimiser = SingleBranchOptimiser {
             cost: &mut self.c,

--- a/phylo/src/optimisers/blen_optimiser.rs
+++ b/phylo/src/optimisers/blen_optimiser.rs
@@ -8,7 +8,7 @@ use log::{debug, info};
 use crate::likelihood::TreeSearchCost;
 use crate::optimisers::{PhyloOptimisationResult, SingleValOptResult};
 use crate::tree::NodeIdx;
-use crate::Result;
+use crate::{Result, MAX_BLEN};
 
 pub struct BranchOptimiser<C: TreeSearchCost + Display + Clone> {
     pub(crate) epsilon: f64,
@@ -80,7 +80,7 @@ impl<C: TreeSearchCost + Clone + Display> BranchOptimiser<C> {
         let (min, max) = if start_blen == 0.0 {
             (0.0, 1.0)
         } else {
-            (start_blen * 0.1, 1e5f64.min(start_blen * 10.0))
+            (start_blen * 0.1, MAX_BLEN.min(start_blen * 10.0))
         };
         let optimiser = SingleBranchOptimiser {
             cost: &mut self.c,

--- a/phylo/src/substitution_models/mod.rs
+++ b/phylo/src/substitution_models/mod.rs
@@ -10,11 +10,12 @@ use nalgebra::{DMatrix, DVector};
 use crate::alphabets::Alphabet;
 use crate::evolutionary_models::EvoModel;
 use crate::likelihood::{ModelSearchCost, TreeSearchCost};
+use crate::phylo_info::PhyloInfo;
 use crate::tree::{
     NodeIdx::{self, Internal, Leaf},
     Tree,
 };
-use crate::{phylo_info::PhyloInfo, Result};
+use crate::{Result, MAX_BLEN};
 
 pub mod dna_models;
 pub use dna_models::*;
@@ -75,8 +76,8 @@ impl<Q: QMatrix> EvoModel for SubstModel<Q> {
     fn p(&self, time: f64) -> SubstMatrix {
         // If time > 1e10f64 the matrix exponentiation breaks and stops converging, but before it breaks
         // starting with 1e5f64 it converges to the same result.
-        if time > 1e5f64 {
-            (self.q().clone() * 1e5f64).exp()
+        if time > MAX_BLEN {
+            (self.q().clone() * MAX_BLEN).exp()
         } else {
             (self.q().clone() * time).exp()
         }

--- a/phylo/src/substitution_models/mod.rs
+++ b/phylo/src/substitution_models/mod.rs
@@ -73,7 +73,13 @@ impl<Q: QMatrix + QMatrixMaker> SubstModel<Q> {
 
 impl<Q: QMatrix> EvoModel for SubstModel<Q> {
     fn p(&self, time: f64) -> SubstMatrix {
-        (self.q().clone() * time).exp()
+        // If time > 1e10f64 the matrix exponentiation breaks and stops converging, but before it breaks
+        // starting with 1e5f64 it converges to the same result.
+        if time > 1e5f64 {
+            (self.q().clone() * 1e5f64).exp()
+        } else {
+            (self.q().clone() * time).exp()
+        }
     }
 
     fn q(&self) -> &SubstMatrix {

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -1220,3 +1220,14 @@ fn protein_avg_rate() {
     avg_rate_template::<HIVB>(freqs, &[]);
     avg_rate_template::<BLOSUM>(freqs, &[]);
 }
+
+#[test]
+fn p_matrix_limit() {
+    let model = SubstModel::<WAG>::new(&[], &[]);
+    let time = 1e10f64;
+    let p = model.p(time);
+    let p2 = model.p(1e3f64);
+    check_freq_convergence(p.clone(), model.freqs(), 1e-5);
+    check_freq_convergence(p2.clone(), model.freqs(), 1e-5);
+    assert_relative_eq!(p, p2, epsilon = 1e-5);
+}


### PR DESCRIPTION
Substitution likelihood was crashing because argmin wanted to keep increasing branch lengths until the transition probability matrix calculation crashed and then went to setting NaN as the branch length in an infinite loop.