### PR TITLE
Fix/rust 1.86 lints

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Skip Duplicate Actions
         uses: fkirc/skip-duplicate-actions@v5.3.1
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.86.0
         with:
           components: rustfmt
       - uses: mbrobbel/rustfmt-check@0.16.0
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.86.0
         with:
           components: clippy
       - uses: actions-rs/clippy-check@v1.0.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.86.0
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/phylo/src/pip_model/mod.rs
+++ b/phylo/src/pip_model/mod.rs
@@ -70,7 +70,7 @@ impl<Q: QMatrix + QMatrixMaker> PIPModel<Q> {
         if params.len() < 2 {
             warn!("Too few values provided for PIP, 2 values required, lambda and mu.");
             warn!("Falling back to default values.");
-            params.extend(iter::repeat(1.5).take(2 - params.len()));
+            params.extend(iter::repeat_n(1.5, 2 - params.len()));
         }
         let mu = params[1];
 

--- a/phylo/src/substitution_models/dna_models/mod.rs
+++ b/phylo/src/substitution_models/dna_models/mod.rs
@@ -296,7 +296,7 @@ impl QMatrixMaker for TN93 {
             Ordering::Less => {
                 warn!("Too few values provided for TN93, required 3 values.");
                 warn!("Falling back to default values.");
-                params.extend(iter::repeat(1.0).take(3 - params.len()));
+                params.extend(iter::repeat_n(1.0, 3 - params.len()));
             }
             Ordering::Greater => {
                 warn!("Too many values provided for TN93, required three values.");
@@ -410,7 +410,7 @@ impl QMatrixMaker for GTR {
         if params.len() < 5 {
             warn!("Too few values provided for GTR, required five values.");
             warn!("Falling back to default values.");
-            params.extend(iter::repeat(1.0).take(5 - params.len()));
+            params.extend(iter::repeat_n(1.0, 5 - params.len()));
         } else if params.len() > 6 {
             warn!("Too many values provided for GTR, required five values.");
             warn!("Will only use the first values provided.");

--- a/phylo/src/tree/tree_parser.rs
+++ b/phylo/src/tree/tree_parser.rs
@@ -95,7 +95,7 @@ impl Tree {
     }
 
     fn complete(&mut self) {
-        self.n = (self.nodes.len() + 1) / 2;
+        self.n = self.nodes.len().div_ceil(2);
         debug_assert_eq!(self.nodes.len(), self.n * 2 - 1);
         self.complete = true;
         self.compute_postorder();


### PR DESCRIPTION
Rust 1.86 added some new lints which caused my bench MR to fail, this MR:
 
- fixes the new lints
- pins CI rust version to 1.86 (except test because cargo2junit requires nightly/unstable)