### PR TITLE
Feature/Implements ancestral alignment

### DIFF
--- a/phylo/src/alignment/alignment_builder.rs
+++ b/phylo/src/alignment/alignment_builder.rs
@@ -138,12 +138,6 @@ impl<'a> AncestralAlignmentBuilder<'a> {
     }
 
     fn build_from_only_aligned_leafs(self) -> std::result::Result<AncestralAlignment, String> {
-        if self.seqs.len() != self.tree.n {
-            return Err("To build an AncestralAlignment only given the leaf seqs, \
-            the number of seqs has to be the same as the number of leaves in the tree"
-                .to_string());
-        }
-
         let leaf_maps: SeqMapping = self
             .tree
             .iter()
@@ -231,11 +225,6 @@ impl<'a> AncestralAlignmentBuilder<'a> {
     fn build_from_aligned_seqs_with_ancestors(
         self,
     ) -> std::result::Result<AncestralAlignment, String> {
-        if self.seqs.len() != self.tree.len() {
-            return Err("To build an AncestralAlignment with given ancestors, \
-            the number of seqs has to be the same as the number of nodes in the tree"
-                .to_string());
-        }
         let seq_map: SeqMapping = self
             .tree
             .iter()

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -198,6 +198,13 @@ impl AncestralAlignment {
     }
 
     pub fn update_nodes(&mut self, new_nodes: SeqMapping) {
+        for (new_node, _) in &new_nodes {
+            assert!(
+                self.seq_map.contains_key(new_node),
+                "The node that is to be updated ({}) is not in the tree.",
+                new_node
+            )
+        }
         self.seq_map.extend(new_nodes);
     }
 }

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -204,19 +204,17 @@ impl AncestralAlignment {
 
 impl Display for AncestralAlignment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let internal = self
-            .seq_map
-            .iter()
-            .filter(|(x, _)| matches!(x, Int(_)))
-            .map(|(x, v)| {
-                format!(
-                    "{x}, {}\n",
-                    v.iter()
-                        .map(|opt| if opt.is_some() { 'X' } else { '-' })
-                        .collect::<String>()
-                )
-            })
-            .collect::<String>();
+        let mut internal = String::new();
+        for (x, v) in self.seq_map.iter() {
+            if !matches!(x, Int(_)) {
+                continue;
+            }
+            internal.push_str(&format!("{x}, "));
+            for opt in v {
+                internal.push(if opt.is_some() { 'X' } else { '-' });
+            }
+            internal.push('\n');
+        }
         write!(f, "{}{}", self.seqs, internal)
     }
 }

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -17,6 +17,7 @@ pub type Position = Option<usize>;
 pub type Mapping = Vec<Option<usize>>;
 pub type InternalMapping = HashMap<NodeIdx, PairwiseAlignment>;
 pub type LeafMapping = HashMap<NodeIdx, Mapping>;
+pub type SeqMapping = HashMap<NodeIdx, Mapping>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PairwiseAlignment {
@@ -171,6 +172,50 @@ impl Alignment {
                 }
             })
             .collect::<Mapping>()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AncestralAlignment {
+    pub(crate) seqs: Sequences,
+    seq_map: SeqMapping,
+    // TODO: implement  node_map: InternalMapping,
+    pub(crate) leaf_encoding: HashMap<String, DMatrix<f64>>,
+}
+
+impl AncestralAlignment {
+    pub fn len(&self) -> usize {
+        self.seq_map
+            .values()
+            .next()
+            .map(|map| map.len())
+            .unwrap_or(0)
+    }
+    pub fn seq_count(&self) -> usize {
+        self.seq_map.len()
+    }
+
+    pub fn update_nodes(&mut self, new_nodes: SeqMapping) {
+        self.seq_map.extend(new_nodes);
+    }
+}
+
+impl Display for AncestralAlignment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let internal = self
+            .seq_map
+            .iter()
+            .filter(|(x, _)| matches!(x, Int(_)))
+            .map(|(x, v)| {
+                format!(
+                    "{x}, {}\n",
+                    v.iter()
+                        .map(|opt| if opt.is_some() { 'X' } else { '-' })
+                        .collect::<String>()
+                )
+            })
+            .collect::<String>();
+        write!(f, "{}{}", self.seqs, internal)
     }
 }
 

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -198,11 +198,10 @@ impl AncestralAlignment {
     }
 
     pub fn update_nodes(&mut self, new_nodes: SeqMapping) {
-        for (new_node, _) in &new_nodes {
+        for new_node in new_nodes.keys() {
             assert!(
                 self.seq_map.contains_key(new_node),
-                "The node that is to be updated ({}) is not in the tree.",
-                new_node
+                "The node that is to be updated ({new_node}) is not in the tree.",
             )
         }
         self.seq_map.extend(new_nodes);

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -180,10 +180,12 @@ pub struct AncestralAlignment {
     pub(crate) seqs: Sequences,
     seq_map: SeqMapping,
     // TODO: implement  node_map: InternalMapping,
+    #[allow(dead_code)]
     pub(crate) leaf_encoding: HashMap<String, DMatrix<f64>>,
 }
 
 impl AncestralAlignment {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.seq_map
             .values()


### PR DESCRIPTION
## This PR is DISCONTINUED! It is continued in #53 

- implements AncestralAlignment struct
- can be built from alignment of all nodes
- can be built from alignment of only leafs (does parismony reconstruction of ancestors)
- wrote tests

## TODOs:
- currently I have a type (SeqMapping) that is the same as `LeafMapping` that I need because in TKF the internal nodes will also have sequences. Either we keep this duplication or try to come up with a more general name for the type that can both be used in the `Alignment` and `AncestralAlignment`
- The internal mapping that was used in `Alignment` which may be used for the realignment step is not implemented yet for `AncestralAlignment`. 