### PR TITLE
Feature/parallel topo variations

### DIFF
--- a/phylo/Cargo.toml
+++ b/phylo/Cargo.toml
@@ -12,6 +12,7 @@ deterministic = []
 use-precomputed-test-results = []
 par-regraft = ["dep:rayon"]
 par-regraft-chunk = ["dep:rayon"]
+par-regraft-manual = ["dep:rayon"]
 
 [lib]
 bench = false

--- a/phylo/Cargo.toml
+++ b/phylo/Cargo.toml
@@ -10,6 +10,8 @@ ci_coverage = []
 deterministic = []
 # Feature that can speed up repeated test runs for when tree search is not affected and tests are ran locally.
 use-precomputed-test-results = []
+par-regraft = ["dep:rayon"]
+par-regraft-chunk = ["dep:rayon"]
 
 [lib]
 bench = false
@@ -47,6 +49,7 @@ ordered-float = "3.7.0"
 pest = "2.7.2"
 pest_derive = "2.7.2"
 rand = "0.8.5"
+rayon = { version = "1.10.0", optional = true }
 rstest = "0.18.1"
 stats-cli = "3.0.1"
 tempfile = "3.8.0"

--- a/phylo/benches/spr.rs
+++ b/phylo/benches/spr.rs
@@ -15,14 +15,14 @@ use helpers::{
     DNA_EASY_17X2292, DNA_EASY_5X1000, DNA_EASY_8X1252,
 };
 
-fn single_spr_cycle<C: TreeSearchCost + Clone + Display>(
+fn single_spr_cycle<C: TreeSearchCost + Clone + Display + Send>(
     mut cost_fn: C,
     prune_locations: &[&NodeIdx],
 ) -> anyhow::Result<f64> {
     spr::fold_improving_moves(&mut cost_fn, f64::MIN, prune_locations)
 }
 
-fn find_best_regraft_for_single_spr_move<C: TreeSearchCost + Clone + Display>(
+fn find_best_regraft_for_single_spr_move<C: TreeSearchCost + Clone + Display + Send>(
     cost_fn: C,
     prune_location: &NodeIdx,
 ) -> anyhow::Result<f64> {
@@ -33,7 +33,7 @@ fn find_best_regraft_for_single_spr_move<C: TreeSearchCost + Clone + Display>(
     Ok(best_regraft.cost())
 }
 
-fn run_single_spr_cycle_for_sizes<Q: QMatrix + QMatrixMaker>(
+fn run_single_spr_cycle_for_sizes<Q: QMatrix + QMatrixMaker + Send>(
     paths: &SequencePaths,
     group_name: &'static str,
     criterion: &mut Criterion,
@@ -62,7 +62,7 @@ fn run_single_spr_cycle_for_sizes<Q: QMatrix + QMatrixMaker>(
     bench_group.finish();
 }
 
-fn run_find_best_regraft_for_single_spr_move<Q: QMatrix + QMatrixMaker>(
+fn run_find_best_regraft_for_single_spr_move<Q: QMatrix + QMatrixMaker + Send>(
     paths: &SequencePaths,
     group_name: &'static str,
     criterion: &mut Criterion,

--- a/phylo/benches/topo.rs
+++ b/phylo/benches/topo.rs
@@ -14,7 +14,7 @@ use helpers::{
     DNA_EASY_8X1252,
 };
 
-fn run_fixed_iter_topo<C: TreeSearchCost + Clone + Display>(cost: C) -> anyhow::Result<f64> {
+fn run_fixed_iter_topo<C: TreeSearchCost + Clone + Display + Send>(cost: C) -> anyhow::Result<f64> {
     let topo_opt = TopologyOptimiser::new_with_pred(
         cost,
         TopologyOptimiserPredicate::fixed_iter(NonZero::new(3).unwrap()),
@@ -22,7 +22,7 @@ fn run_fixed_iter_topo<C: TreeSearchCost + Clone + Display>(cost: C) -> anyhow::
     Ok(topo_opt.run()?.final_cost)
 }
 
-fn run_simulated_topo_for_sizes<Q: QMatrix + QMatrixMaker>(
+fn run_simulated_topo_for_sizes<Q: QMatrix + QMatrixMaker + Send>(
     paths: &SequencePaths,
     group_name: &'static str,
     criterion: &mut Criterion,

--- a/phylo/benches/tree_from_msa.rs
+++ b/phylo/benches/tree_from_msa.rs
@@ -24,7 +24,7 @@ use helpers::{
 ///
 /// TODO: expose this as part of the rust-phylo library
 fn run_optimisation(
-    cost: impl TreeSearchCost + ModelSearchCost + Display + Clone,
+    cost: impl TreeSearchCost + ModelSearchCost + Display + Clone + Send,
     freq_opt: FrequencyOptimisation,
     max_iterations: usize,
     epsilon: f64,
@@ -49,7 +49,7 @@ fn run_optimisation(
     Ok((final_cost, cost.tree().clone()))
 }
 
-fn run_for_sizes<Q: QMatrix + QMatrixMaker>(
+fn run_for_sizes<Q: QMatrix + QMatrixMaker + Send>(
     paths: &SequencePaths,
     group_name: &'static str,
     criterion: &mut Criterion,

--- a/phylo/src/optimisers/regraft_optimiser.rs
+++ b/phylo/src/optimisers/regraft_optimiser.rs
@@ -67,36 +67,24 @@ impl<'a, C: TreeSearchCost + Clone + Display + Send> RegraftOptimiser<'a, C> {
         let regraft_locations = self.available_regraft_locations().copied().collect_vec();
 
         info!("Node {:?}: trying to regraft", self.prune_location);
-        // NOTE: collecting the moves into a Vec before finding the max instead of iterating
-        // over lazy iterators proved to be minutely faster/equal to (both rayon::try_reduce and for
-        // loop over std Iterator)
-        let moves = calc_regraft_costs(
+        let best_regraft = calc_best_regraft_cost(
             base_cost,
             *self.prune_location,
             regraft_locations,
             self.cost_fn,
         )?;
-
-        let best_regraft = moves
-            .into_iter()
-            .max_by(|left, right| {
-                left.cost
-                    .partial_cmp(&right.cost)
-                    .expect("tree cost should be a number")
-            })
-            .expect("at least one SPR move has to be evaluated");
         Ok(Some(best_regraft))
     }
 }
 
 cfg_if::cfg_if! {
 if #[cfg(feature="par-regraft")] {
-fn calc_regraft_costs<C: TreeSearchCost + Clone + Display + Send>(
+fn calc_best_regraft_cost<C: TreeSearchCost + Clone + Display + Send>(
     base_cost: f64,
     prune_location: NodeIdx,
     regraft_locations: Vec<NodeIdx>,
     cost: &C,
-) -> Result<Vec<RegraftCostInfo>> {
+) -> Result<RegraftCostInfo> {
     use rayon::prelude::*;
     let cost_funcs = vec![cost.clone(); regraft_locations.len()];
     regraft_locations
@@ -105,47 +93,94 @@ fn calc_regraft_costs<C: TreeSearchCost + Clone + Display + Send>(
         .map(move |(regraft, cost_fn)| {
             calc_spr_cost_with_blen_opt(prune_location, regraft, base_cost, cost_fn.clone())
         })
-        .collect()
+        .try_reduce_with(|left, right| Ok(if left.cost() > right.cost() {left} else {right})).expect("at least one regraft location")
 }
 } else if #[cfg(feature="par-regraft-chunk")] {
 /// NOTE: seems to be faster than full on parallel for few taxa
-fn calc_regraft_costs<C: TreeSearchCost + Clone + Display + Send>(
+fn calc_best_regraft_cost<C: TreeSearchCost + Clone + Display + Send>(
     base_cost: f64,
     prune_location: NodeIdx,
     regraft_locations: Vec<NodeIdx>,
     cost: &C,
-) -> Result<Vec<RegraftCostInfo>> {
+) -> Result<RegraftCostInfo> {
     use rayon::prelude::*;
     // TODO: determine better factor (maybe dynamically)
     const CHUNK_SIZE: usize = 2;
     let cost_funcs = vec![cost.clone(); regraft_locations.len().div_ceil(CHUNK_SIZE)];
+
     regraft_locations
         .par_chunks(CHUNK_SIZE)
         .zip_eq(cost_funcs)
         .map(move |(regrafts, cost_func)| -> Result<_> {
             let mut max: Option<RegraftCostInfo> = None;
+            let mut max_cost = f64::MIN;
             for regraft_result in regrafts.iter().map(move |regraft| {
                 calc_spr_cost_with_blen_opt(prune_location, *regraft, base_cost, cost_func.clone())
             }) {
-                let regraft = regraft_result?;
-                if max.as_ref().is_none_or(|max| max.cost > regraft.cost) {
-                    max = Some(regraft);
+                match result {
+                    Ok(regraft_info) if regraft_info.cost() > max_cost => {
+                        max_cost = regraft_info.cost();
+                        max = Some(regraft_info);
+                    },
+                    Ok(_) => {}
+                    Err(error) => return Err(error),
                 }
             }
             Ok(max.expect("at least one regraft location"))
         })
-        .collect()
+        .try_reduce_with(|left, right| Ok(if left.cost() > right.cost() {left} else {right})).expect("at least one regraft location")
 }
-} else {
-fn calc_regraft_costs<C: TreeSearchCost + Clone + Display + Send>(
+} else if #[cfg(feature="par-regraft-manual")] {
+fn calc_best_regraft_cost<C: TreeSearchCost + Clone + Display + Send>(
     base_cost: f64,
     prune_location: NodeIdx,
     regraft_locations: Vec<NodeIdx>,
     cost: &C,
-) -> Result<Vec<RegraftCostInfo>> {
-    regraft_locations.into_iter().map(move |regraft| {
+) -> Result<RegraftCostInfo> {
+    #[derive(Clone)]
+    struct RecursiveForkJoinRegrafter<C: TreeSearchCost + Clone + Display + Send> {
+        cost_fn: C,
+        prune_location: NodeIdx,
+        base_cost: f64,
+    }
+    /// NOTE: by being recursive these tasks can be stored solely on the stack
+    /// using rayon::scope might look simpler but incurrs overhead by having to manage
+    /// tasks on the heap
+    fn regraft_recursive<C: TreeSearchCost + Clone + Display + Send>(state: RecursiveForkJoinRegrafter<C>, regraft_locations: &[NodeIdx]) -> Result<RegraftCostInfo> {
+        if regraft_locations.len() == 1 {
+            return calc_spr_cost_with_blen_opt(state.prune_location, regraft_locations[0], state.base_cost, state.cost_fn);
+        }
+        let (left_locations, right_locations) = regraft_locations.split_at(regraft_locations.len() / 2);
+        let r2 = state.clone();
+        match rayon::join(move || regraft_recursive(state, left_locations), move ||regraft_recursive(r2, right_locations)) {
+            (Ok(left), Ok(right)) => Ok(if left.cost() > right.cost() {left} else {right}) ,
+            (Err(error), _) | (_, Err(error))   => Err(error),
+        }
+    }
+    regraft_recursive(RecursiveForkJoinRegrafter { cost_fn: cost.clone(), prune_location, base_cost }, &regraft_locations)
+}
+} else {
+fn calc_best_regraft_cost<C: TreeSearchCost + Clone + Display + Send>(
+    base_cost: f64,
+    prune_location: NodeIdx,
+    regraft_locations: Vec<NodeIdx>,
+    cost: &C,
+) -> Result<RegraftCostInfo> {
+    let mut max = None;
+    let mut max_cost = f64::MIN;
+    for regraft in regraft_locations.into_iter().map(move |regraft| {
         calc_spr_cost_with_blen_opt(prune_location, regraft, base_cost, cost.clone())
-    }).collect()
+    }) {
+        match regraft {
+            Ok(regraft_info) if regraft_info.cost() > max_cost => {
+                max_cost = regraft_info.cost();
+                max = Some(regraft_info);
+            },
+            Ok(_) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(max.expect("at least one regraft location"))
 }
 }}
 

--- a/phylo/src/optimisers/topo_optimiser.rs
+++ b/phylo/src/optimisers/topo_optimiser.rs
@@ -37,12 +37,12 @@ impl TopologyOptimiserPredicate {
     }
 }
 
-pub struct TopologyOptimiser<C: TreeSearchCost + Display + Clone> {
+pub struct TopologyOptimiser<C: TreeSearchCost + Display + Clone + Send> {
     pub(crate) predicate: TopologyOptimiserPredicate,
     pub(crate) c: C,
 }
 
-impl<C: TreeSearchCost + Clone + Display> TopologyOptimiser<C> {
+impl<C: TreeSearchCost + Clone + Display + Send> TopologyOptimiser<C> {
     // TODO: make tree search work under parsimony
     pub fn new(cost: C) -> Self {
         Self {
@@ -129,7 +129,7 @@ pub mod spr {
     /// SPR move for each pruneing location in place
     /// # Returns:
     /// - the new cost (or `base_cost` if no improvement was found)
-    pub fn fold_improving_moves<C: TreeSearchCost + Display + Clone>(
+    pub fn fold_improving_moves<C: TreeSearchCost + Display + Clone + Send>(
         cost_fn: &mut C,
         base_cost: f64,
         prune_locations: &[&NodeIdx],

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -22,7 +22,7 @@ macro_rules! define_optimise_trees {
     ($($fn_name:ident: { model = $model:ident, cost = $cost:ident, builder = $builder:ident }),* $(,)?) => {
         $(
             #[cfg(not(feature = "use-precomputed-test-results"))]
-            fn $fn_name<Q: QMatrix>(
+            fn $fn_name<Q: QMatrix + Send>(
                 seq_file: &std::path::Path,
                 _: &std::path::Path,
                 model: $model<Q>,
@@ -33,7 +33,7 @@ macro_rules! define_optimise_trees {
             }
 
             #[cfg(feature = "use-precomputed-test-results")]
-            fn $fn_name<Q: QMatrix>(
+            fn $fn_name<Q: QMatrix + Send>(
                 seq_file: &std::path::Path,
                 tree_file: &std::path::Path,
                 model: $model<Q>,


### PR DESCRIPTION
NOTE: DO-NOT-SQUASH
these 2 commits are intended to be measured independently


adds 2 iterations of different version of parallel regraft/topology optimisation

namely we search for the best scoring SPR move in parallel using rayon
- `par-regraft` simplest way possible using just par_iter and leaving everthing to rayon
- `par-regraft-chunk`  try to reduce thread overhead for smaller sets by running a fixed chunk per task
   this should reduce overhead if the unit of work is too small to warrant it
- `par-regraft-manual` a completely hand crafted forkjoin implementation using rayon that should in theory avoid heap allocations  (for tasks) almost entirely

