### PR TITLE
Release prep/replace pathbufs

### DIFF
--- a/phylo/src/alignment/sequences.rs
+++ b/phylo/src/alignment/sequences.rs
@@ -161,8 +161,6 @@ impl Sequences {
 mod private_tests {
     use rstest::rstest;
 
-    use std::path::PathBuf;
-
     use crate::io::read_sequences;
 
     use super::*;
@@ -172,7 +170,7 @@ mod private_tests {
     #[case::unaligned("./data/sequences_DNA2_unaligned.fasta")]
     #[case::long("./data/sequences_long.fasta")]
     fn dna_type_test(#[case] input: &str) {
-        let seqs = read_sequences(&PathBuf::from(input)).unwrap();
+        let seqs = read_sequences(input).unwrap();
         let alphabet = Sequences::detect_alphabet(&seqs);
         assert_eq!(alphabet, dna_alphabet());
         assert!(format!("{alphabet}").contains("DNA"));
@@ -182,7 +180,7 @@ mod private_tests {
     #[case("./data/sequences_protein1.fasta")]
     #[case("./data/sequences_protein2.fasta")]
     fn protein_type_test(#[case] input: &str) {
-        let seqs = read_sequences(&PathBuf::from(input)).unwrap();
+        let seqs = read_sequences(input).unwrap();
         let alphabet = Sequences::detect_alphabet(&seqs);
         assert_eq!(alphabet, protein_alphabet());
         assert!(format!("{alphabet}").contains("protein"));

--- a/phylo/src/alignment/tests.rs
+++ b/phylo/src/alignment/tests.rs
@@ -1,11 +1,8 @@
-use std::path::PathBuf;
-
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
 
-use crate::alignment::Alignment;
 use crate::alignment::{
-    sequences::Sequences, InternalMapping, LeafMapping, PairwiseAlignment as PA,
+    Alignment, InternalMapping, LeafMapping, PairwiseAlignment as PA, Sequences,
 };
 use crate::alphabets::{dna_alphabet, protein_alphabet, AMINOACIDS, NUCLEOTIDES};
 use crate::io::read_sequences;
@@ -236,8 +233,7 @@ fn compile_msa_leaf() {
 #[test]
 fn input_msa_empty_col() {
     let tree = test_tree();
-    let sequences =
-        Sequences::new(read_sequences(&PathBuf::from("./data/sequences_empty_col.fasta")).unwrap());
+    let sequences = Sequences::new(read_sequences("./data/sequences_empty_col.fasta").unwrap());
     let msa = Alignment::from_aligned(sequences, &tree).unwrap();
     assert_eq!(msa.len(), 40 - 1);
     assert_eq!(msa.seq_count(), 5);
@@ -245,8 +241,7 @@ fn input_msa_empty_col() {
 
 #[test]
 fn display_sequences() {
-    let sequences =
-        Sequences::new(read_sequences(&PathBuf::from("./data/sequences_DNA1.fasta")).unwrap());
+    let sequences = Sequences::new(read_sequences("./data/sequences_DNA1.fasta").unwrap());
     let s = format!("{sequences}");
     let mut lines = s.lines().collect::<Vec<_>>();
     lines.sort();
@@ -260,9 +255,8 @@ fn display_sequences() {
 
 #[test]
 fn display_unaligned_sequences() {
-    let sequences = Sequences::new(
-        read_sequences(&PathBuf::from("./data/sequences_DNA2_unaligned.fasta")).unwrap(),
-    );
+    let sequences =
+        Sequences::new(read_sequences("./data/sequences_DNA2_unaligned.fasta").unwrap());
     let s = format!("{sequences}");
     let mut lines = s.lines().collect::<Vec<_>>();
     lines.sort();
@@ -277,8 +271,7 @@ fn display_unaligned_sequences() {
 #[test]
 fn display_alignment() {
     let tree = tree!("(C:0.06465432,D:27.43128366,(A:0.00000001,B:0.00000001):0.08716381);");
-    let sequences =
-        Sequences::new(read_sequences(&PathBuf::from("./data/sequences_DNA1.fasta")).unwrap());
+    let sequences = Sequences::new(read_sequences("./data/sequences_DNA1.fasta").unwrap());
     let msa = Alignment::from_aligned(sequences, &tree).unwrap();
 
     let s = format!("{}", msa.compile(&tree).unwrap());

--- a/phylo/src/io/mod.rs
+++ b/phylo/src/io/mod.rs
@@ -148,10 +148,7 @@ pub fn write_sequences_to_file(sequences: &[Record], path: impl AsRef<Path>) -> 
 /// # assert_eq!(trees[0].leaves().len(), 4);
 /// ```
 pub fn read_newick_from_file(path: impl AsRef<Path>) -> Result<Vec<Tree>> {
-    info!(
-        "Reading newick trees from file {}",
-        path.as_ref().to_path_buf().display()
-    );
+    info!("Reading newick trees from file {}", path.as_ref().display());
     let newick = fs::read_to_string(path)?;
     info!("Read file successfully");
     tree_parser::from_newick(&newick)

--- a/phylo/src/io/tests.rs
+++ b/phylo/src/io/tests.rs
@@ -2,7 +2,6 @@ use rstest::*;
 
 use std::fs::File;
 use std::io::Read;
-use std::path::PathBuf;
 
 use tempfile::tempdir;
 
@@ -11,15 +10,14 @@ use crate::{record_wo_desc as record, tree};
 
 #[test]
 fn reading_correct_fasta() {
-    let sequences = read_sequences(&PathBuf::from("./data/sequences_DNA1.fasta")).unwrap();
+    let sequences = read_sequences("./data/sequences_DNA1.fasta").unwrap();
     assert_eq!(sequences.len(), 4);
     for seq in sequences {
         assert_eq!(seq.seq().len(), 5);
     }
 
     let corr_lengths = [1, 2, 2, 4];
-    let sequences =
-        read_sequences(&PathBuf::from("./data/sequences_DNA2_unaligned.fasta")).unwrap();
+    let sequences = read_sequences("./data/sequences_DNA2_unaligned.fasta").unwrap();
     assert_eq!(sequences.len(), 4);
     for (i, seq) in sequences.into_iter().enumerate() {
         assert_eq!(seq.seq().len(), corr_lengths[i]);
@@ -37,14 +35,14 @@ fn reading_correct_fasta() {
     "Invalid genetic sequence"
 )]
 fn reading_incorrect_fasta(#[case] input: &str, #[case] exp_error: &str) {
-    let res = read_sequences(&PathBuf::from(input));
+    let res = read_sequences(input);
     assert!(res.is_err());
     assert!(res.unwrap_err().to_string().contains(exp_error));
 }
 
 #[test]
 fn reading_nonexistent_fasta() {
-    assert!(read_sequences(&PathBuf::from("./data/sequences_nonexistent.fasta")).is_err());
+    assert!(read_sequences("./data/sequences_nonexistent.fasta").is_err());
 }
 
 #[test]
@@ -145,11 +143,9 @@ fn test_write_newick_to_existing_file() {
 
 #[test]
 fn read_sequences_weird_gap_chars() {
-    let sequences_underscore =
-        read_sequences(&PathBuf::from("./data/sequences_gap_underscore.fasta")).unwrap();
-    let sequences_asterisk =
-        read_sequences(&PathBuf::from("./data/sequences_gap_asterisk.fasta")).unwrap();
-    let sequences = read_sequences(&PathBuf::from("./data/sequences_gap_normal.fasta")).unwrap();
+    let sequences_underscore = read_sequences("./data/sequences_gap_underscore.fasta").unwrap();
+    let sequences_asterisk = read_sequences("./data/sequences_gap_asterisk.fasta").unwrap();
+    let sequences = read_sequences("./data/sequences_gap_normal.fasta").unwrap();
 
     assert_eq!(sequences.len(), 4);
     assert_eq!(sequences_underscore.len(), sequences.len());

--- a/phylo/src/likelihood/tests.rs
+++ b/phylo/src/likelihood/tests.rs
@@ -28,7 +28,7 @@ fn test_subst_model<Q: QMatrix + QMatrixMaker>(
 
     let fldr = Path::new("./data");
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
-    let records = read_sequences(&fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
+    let records = read_sequences(fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
     let msa =
         Alignment::from_aligned(Sequences::with_alphabet(records.clone(), alpha), &tree).unwrap();
     let info = PhyloInfo { msa, tree };
@@ -78,7 +78,7 @@ fn test_pip_model<Q: QMatrix + QMatrixMaker>(
     // https://molevolworkshop.github.io/faculty/huelsenbeck/pdf/WoodsHoleHandout.pdf
 
     let fldr = Path::new("./data");
-    let records = read_sequences(&fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
+    let records = read_sequences(fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
 
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
     let msa =
@@ -145,7 +145,7 @@ fn alphabet_mismatch_subst_model_template<Q: QMatrix + QMatrixMaker>(
 ) {
     // https://molevolworkshop.github.io/faculty/huelsenbeck/pdf/WoodsHoleHandout.pdf
     let fldr = Path::new("./data");
-    let records = read_sequences(&fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
+    let records = read_sequences(fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
     let msa = Alignment::from_aligned(Sequences::with_alphabet(records, alpha), &tree).unwrap();
     let info = PhyloInfo { msa, tree };
@@ -188,7 +188,7 @@ fn alphabet_mismatch_subst_pip_template<Q: QMatrix + QMatrixMaker>(
 ) {
     // https://molevolworkshop.github.io/faculty/huelsenbeck/pdf/WoodsHoleHandout.pdf
     let fldr = Path::new("./data");
-    let records = read_sequences(&fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
+    let records = read_sequences(fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
     let msa =
         Alignment::from_aligned(Sequences::with_alphabet(records.clone(), alpha), &tree).unwrap();

--- a/phylo/src/optimisers/topo_optimiser.rs
+++ b/phylo/src/optimisers/topo_optimiser.rs
@@ -67,14 +67,12 @@ impl<C: TreeSearchCost + Clone + Display + Send> TopologyOptimiser<C> {
     /// # Example
     /// ```rust
     /// # fn main() -> std::result::Result<(), anyhow::Error> {
-    /// use std::path::Path;
-    ///
     /// use phylo::likelihood::TreeSearchCost;
     /// use phylo::optimisers::TopologyOptimiser;
     /// use phylo::phylo_info::PhyloInfoBuilder;
     /// use phylo::substitution_models::{SubstModel, SubstitutionCostBuilder, K80};
     ///
-    /// let info = PhyloInfoBuilder::new(Path::new("./examples/data/K80.fasta").to_path_buf()).build()?;
+    /// let info = PhyloInfoBuilder::new("./examples/data/K80.fasta").build()?;
     /// let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     /// let c = SubstitutionCostBuilder::new(k80, info).build()?;
     /// let unopt_cost = c.cost();

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -29,7 +29,7 @@ macro_rules! define_optimise_trees {
                 _: &std::path::Path,
                 model: $model<Q>,
             ) -> PhyloOptimisationResult<$cost<Q>> {
-                let start_info = PIB::new(seq_file.to_path_buf()).build().unwrap();
+                let start_info = PIB::new(seq_file).build().unwrap();
                 let cost = $builder::new(model, start_info).build().unwrap();
                 TopologyOptimiser::new(cost).run().unwrap()
             }
@@ -40,10 +40,10 @@ macro_rules! define_optimise_trees {
                 tree_file: &std::path::Path,
                 model: $model<Q>,
             ) -> PhyloOptimisationResult<$cost<Q>> {
-                let start_info = PIB::new(seq_file.to_path_buf()).build().unwrap();
+                let start_info = PIB::new(seq_file).build().unwrap();
 
                 if let Ok(precomputed) =
-                    PIB::with_attrs(seq_file.to_path_buf(), tree_file.to_path_buf()).build()
+                    PIB::with_attrs(seq_file, tree_file).build()
                 {
                     let initial_cost = $builder::new(model.clone(), start_info).build().unwrap();
                     let final_cost = $builder::new(model, precomputed.clone()).build().unwrap();
@@ -59,7 +59,7 @@ macro_rules! define_optimise_trees {
                     let res = TopologyOptimiser::new(cost).run().unwrap();
                     assert!(crate::io::write_newick_to_file(
                         &[res.cost.tree().clone()],
-                        tree_file.to_path_buf()
+                        tree_file
                     )
                     .is_ok());
                     res

--- a/phylo/src/phylo_info/mod.rs
+++ b/phylo/src/phylo_info/mod.rs
@@ -39,13 +39,12 @@ impl PhyloInfo {
     ///
     /// # Example
     /// ```
-    /// use std::path::PathBuf;
     /// use phylo::frequencies;
     /// use phylo::phylo_info::PhyloInfoBuilder;
     /// use phylo::substitution_models::FreqVector;
     /// let info = PhyloInfoBuilder::with_attrs(
-    ///     PathBuf::from("./examples/data/sequences_DNA1.fasta"),
-    ///     PathBuf::from("./examples/data/tree_diff_branch_lengths_2.newick"))
+    ///     "./examples/data/sequences_DNA1.fasta",
+    ///     "./examples/data/tree_diff_branch_lengths_2.newick")
     /// .build()
     /// .unwrap();
     /// let freqs = info.freqs();

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -159,10 +159,7 @@ impl PhyloInfoBuilder {
     }
 
     fn read_tree(&self, sequences: &Sequences, tree_file: impl AsRef<Path>) -> Result<Tree> {
-        info!(
-            "Reading trees from file {}",
-            tree_file.as_ref().to_path_buf().display()
-        );
+        info!("Reading trees from file {}", tree_file.as_ref().display());
         let mut trees = io::read_newick_from_file(tree_file)?;
         info!("{} tree(s) read successfully", trees.len());
         self.check_tree_number(&trees)?;

--- a/phylo/src/phylo_info/tests.rs
+++ b/phylo/src/phylo_info/tests.rs
@@ -1,5 +1,5 @@
 use std::fmt::{Debug, Display};
-use std::path::PathBuf;
+use std::path::Path;
 
 use approx::assert_relative_eq;
 use assert_matches::assert_matches;
@@ -63,7 +63,7 @@ fn empirical_frequencies() {
 
 #[test]
 fn setup_info_correct_unaligned() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let res_info = PIB::with_attrs(
         fldr.join("sequences_DNA2_unaligned.fasta"),
         fldr.join("tree_diff_branch_lengths_2.newick"),
@@ -74,7 +74,7 @@ fn setup_info_correct_unaligned() {
 
 #[test]
 fn setup_info_mismatched_ids_missing_tips() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_DNA2_unaligned.fasta"),
         fldr.join("tree_diff_branch_lengths_1.newick"),
@@ -86,7 +86,7 @@ fn setup_info_mismatched_ids_missing_tips() {
 
 #[test]
 fn setup_info_mismatched_ids_missing_sequences() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_DNA2_unaligned.fasta"),
         fldr.join("tree_diff_branch_lengths_3.newick"),
@@ -98,7 +98,7 @@ fn setup_info_mismatched_ids_missing_sequences() {
 
 #[test]
 fn setup_info_missing_sequence_file() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_DNA_nonexistent.fasta"),
         fldr.join("tree_diff_branch_lengths_1.newick"),
@@ -112,7 +112,7 @@ fn setup_info_missing_sequence_file() {
 
 #[test]
 fn setup_info_empty_sequence_file() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_empty.fasta"),
         fldr.join("tree_diff_branch_lengths_1.newick"),
@@ -126,7 +126,7 @@ fn setup_info_empty_sequence_file() {
 
 #[test]
 fn setup_info_empty_tree_file() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_DNA2_unaligned.fasta"),
         fldr.join("tree_empty.newick"),
@@ -140,7 +140,7 @@ fn setup_info_empty_tree_file() {
 
 #[test]
 fn setup_info_malformed_tree_file() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_DNA2_unaligned.fasta"),
         fldr.join("tree_malformed.newick"),
@@ -153,7 +153,7 @@ fn setup_info_malformed_tree_file() {
 
 #[test]
 fn setup_info_multiple_trees() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let res_info = PIB::with_attrs(
         fldr.join("sequences_DNA1.fasta"),
         fldr.join("tree_multiple.newick"),
@@ -166,7 +166,7 @@ fn setup_info_multiple_trees() {
 
 #[test]
 fn setup_unaligned() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_DNA2_unaligned.fasta"),
         fldr.join("tree_diff_branch_lengths_2.newick"),
@@ -177,7 +177,7 @@ fn setup_unaligned() {
 
 #[test]
 fn setup_aligned_msa() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_DNA1.fasta"),
         fldr.join("tree_diff_branch_lengths_2.newick"),
@@ -189,15 +189,14 @@ fn setup_aligned_msa() {
         assert!(!rec.seq().is_empty());
         assert_eq!(rec.seq().to_ascii_uppercase(), rec.seq());
     });
-    let sequences =
-        Sequences::new(read_sequences(&PathBuf::from("./data/sequences_DNA1.fasta")).unwrap());
+    let sequences = Sequences::new(read_sequences("./data/sequences_DNA1.fasta").unwrap());
     let aligned_sequences = info.compile_alignment(None).unwrap();
     assert_eq!(aligned_sequences, sequences);
 }
 
 #[test]
 fn correct_setup_when_sequences_empty() {
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::with_attrs(
         fldr.join("sequences_some_empty.fasta"),
         fldr.join("tree_diff_branch_lengths_2.newick"),
@@ -209,7 +208,7 @@ fn correct_setup_when_sequences_empty() {
         assert_eq!(rec.seq().to_ascii_uppercase(), rec.seq());
     });
     let sequences =
-        Sequences::new(read_sequences(&fldr.join("sequences_some_empty.fasta")).unwrap());
+        Sequences::new(read_sequences(fldr.join("sequences_some_empty.fasta")).unwrap());
     let aligned_sequences = info.compile_alignment(None).unwrap();
     assert_eq!(aligned_sequences, sequences);
 }
@@ -217,8 +216,8 @@ fn correct_setup_when_sequences_empty() {
 #[test]
 fn check_phyloinfo_creation_tree_no_seqs() {
     let info = PIB::with_attrs(
-        PathBuf::from("./data/sequences_empty.fasta"),
-        PathBuf::from("./data/tree_diff_branch_lengths_1.newick"),
+        Path::new("./data/sequences_empty.fasta"),
+        Path::new("./data/tree_diff_branch_lengths_1.newick"),
     )
     .build();
     assert!(info.is_err());
@@ -227,8 +226,8 @@ fn check_phyloinfo_creation_tree_no_seqs() {
 #[test]
 fn check_phyloinfo_creation_newick_mismatch_ids() {
     let info = PIB::with_attrs(
-        PathBuf::from("./data/sequences_protein1.fasta"),
-        PathBuf::from("./data/tree_diff_branch_lengths_1.newick"),
+        Path::new("./data/sequences_protein1.fasta"),
+        Path::new("./data/tree_diff_branch_lengths_1.newick"),
     )
     .build();
     assert!(info.is_err());
@@ -355,11 +354,11 @@ fn empirical_frequencies_no_aas() {
 #[test]
 fn force_protein_alphabet() {
     // If data is severely subsampled it might look like DNA even though it's really protein
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::new(fldr.join("p226.msa.fa")).build().unwrap();
     assert_eq!(info.msa.alphabet(), &dna_alphabet());
 
-    let fldr = PathBuf::from("./data");
+    let fldr = Path::new("./data");
     let info = PIB::new(fldr.join("p226.msa.fa"))
         .alphabet(Some(protein_alphabet()))
         .build()

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use approx::assert_relative_eq;
 use nalgebra::{DMatrix, DVector};
@@ -539,8 +539,8 @@ fn pip_hky_likelihood_example_2() {
 #[test]
 fn pip_likelihood_huelsenbeck_example() {
     let info = PIB::with_attrs(
-        PathBuf::from("./data/Huelsenbeck_example_long_DNA.fasta"),
-        PathBuf::from("./data/Huelsenbeck_example.newick"),
+        "./data/Huelsenbeck_example_long_DNA.fasta",
+        "./data/Huelsenbeck_example.newick",
     )
     .build()
     .unwrap();
@@ -568,8 +568,8 @@ fn pip_likelihood_huelsenbeck_example() {
 #[test]
 fn pip_likelihood_huelsenbeck_example_model_comp() {
     let info = PIB::with_attrs(
-        PathBuf::from("./data/Huelsenbeck_example_long_DNA.fasta"),
-        PathBuf::from("./data/Huelsenbeck_example.newick"),
+        "./data/Huelsenbeck_example_long_DNA.fasta",
+        "./data/Huelsenbeck_example.newick",
     )
     .build()
     .unwrap();
@@ -585,8 +585,8 @@ fn pip_likelihood_huelsenbeck_example_model_comp() {
 #[test]
 fn pip_likelihood_huelsenbeck_example_reroot() {
     let phylo = PIB::with_attrs(
-        PathBuf::from("./data/Huelsenbeck_example_long_DNA.fasta"),
-        PathBuf::from("./data/Huelsenbeck_example.newick"),
+        "./data/Huelsenbeck_example_long_DNA.fasta",
+        "./data/Huelsenbeck_example.newick",
     )
     .build()
     .unwrap();
@@ -595,8 +595,8 @@ fn pip_likelihood_huelsenbeck_example_reroot() {
         &[0.5, 0.25, 1.25453, 1.07461, 1.0, 1.14689, 1.53244, 1.47031],
     );
     let phylo_rerooted = PIB::with_attrs(
-        PathBuf::from("./data/Huelsenbeck_example_long_DNA.fasta"),
-        PathBuf::from("./data/Huelsenbeck_example_reroot.newick"),
+        "./data/Huelsenbeck_example_long_DNA.fasta",
+        "./data/Huelsenbeck_example_reroot.newick",
     )
     .build()
     .unwrap();
@@ -610,8 +610,8 @@ fn pip_likelihood_huelsenbeck_example_reroot() {
 #[test]
 fn pip_likelihood_protein_example() {
     let info = PIB::with_attrs(
-        PathBuf::from("./data/phyml_protein_example/seqs.fasta"),
-        PathBuf::from("./data/phyml_protein_example/example_tree.newick"),
+        "./data/phyml_protein_example/seqs.fasta",
+        "./data/phyml_protein_example/example_tree.newick",
     )
     .build()
     .unwrap();
@@ -801,7 +801,7 @@ fn protein_avg_rate() {
 fn logl_not_inf_for_empty_col() {
     let tree = tree!("((A0:1.0, B1:1.0) I5:1.0,(C2:1.0,(D3:1.0, E4:1.0) I6:1.0) I7:1.0) I8:1.0;");
     let msa = Alignment::from_aligned(
-        Sequences::new(read_sequences(&PathBuf::from("./data/sequences_empty_col.fasta")).unwrap()),
+        Sequences::new(read_sequences("./data/sequences_empty_col.fasta").unwrap()),
         &tree,
     )
     .unwrap();

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -977,7 +977,7 @@ fn dna_gaps_against_phyml() {
     let tree =
         tree!("(C:0.06465432,D:27.43128366,(A:0.00000001,B:0.00000001)0.000000:0.08716381);");
     let seqs =
-        Sequences::new(read_sequences(&Path::new("./data/").join("sequences_DNA1.fasta")).unwrap());
+        Sequences::new(read_sequences(Path::new("./data/").join("sequences_DNA1.fasta")).unwrap());
     let info = PhyloInfo {
         msa: Alignment::from_aligned(seqs, &tree).unwrap(),
         tree,

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -994,11 +994,11 @@ fn rf_distance_to_itself() {
 #[test]
 fn rf_distance_against_raxml() {
     let folder = Path::new("./data/phyml_protein_example");
-    let tree_orig = &read_newick_from_file(&folder.join("example_tree.newick")).unwrap()[0];
-    let tree_phyml = &read_newick_from_file(&folder.join("phyml_nogap.newick")).unwrap()[0];
+    let tree_orig = &read_newick_from_file(folder.join("example_tree.newick")).unwrap()[0];
+    let tree_phyml = &read_newick_from_file(folder.join("phyml_nogap.newick")).unwrap()[0];
 
-    let tree = &read_newick_from_file(&folder.join("test_tree_1.newick")).unwrap()[0];
-    let tree_from_nj = &read_newick_from_file(&folder.join("test_tree_2.newick")).unwrap()[0];
+    let tree = &read_newick_from_file(folder.join("test_tree_1.newick")).unwrap()[0];
+    let tree_from_nj = &read_newick_from_file(folder.join("test_tree_2.newick")).unwrap()[0];
     assert_eq!(tree_orig.robinson_foulds(tree_phyml), 4);
     assert_eq!(tree_orig.robinson_foulds(tree), 4);
     assert_eq!(tree_orig.robinson_foulds(tree_from_nj), 4);


### PR DESCRIPTION
Refactored file path handling across multiple modules replacing `PathBuf` with the more generic `impl AsRef<Path>` wherever possible, simplifying the code and enabling more input types. Additionally, update relevant test cases and documentation to reflect these changes.