### PR TITLE
Replace unwrap() with ? in doctests

### DIFF
--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -54,15 +54,17 @@ impl Alignment {
     /// use phylo::alignment::Sequences;
     /// use phylo::alphabets::dna_alphabet;
     /// use phylo::{record, tree};
+    /// # fn main() -> std::result::Result<(), anyhow::Error> {
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
     /// let seqs = Sequences::with_alphabet(vec![
     ///     record!("A0", Some("A0 sequence"), b"AAAA"),
     ///     record!("B1", Some("B1 sequence"), b"---A"),
     ///     record!("C2", Some("C2 sequence"), b"AA--"),
     /// ], dna_alphabet());
-    /// let msa = Alignment::from_aligned(seqs, &tree).unwrap();
+    /// let msa = Alignment::from_aligned(seqs, &tree)?;
     /// assert_eq!(*msa.alphabet(), dna_alphabet());
-    ///
+    /// # Ok(()) }
+    /// ```
     pub fn alphabet(&self) -> &Alphabet {
         &self.seqs.alphabet
     }
@@ -75,14 +77,16 @@ impl Alignment {
     /// use phylo::alignment::Alignment;
     /// use phylo::alignment::Sequences;
     /// use phylo::{record, tree};
+    /// # fn main() -> std::result::Result<(), anyhow::Error> {
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
     /// let seqs = Sequences::new(vec![
     ///     record!("A0", Some("A0 sequence"), b"AAAA"),
     ///     record!("B1", Some("B1 sequence"), b"---A"),
     ///     record!("C2", Some("C2 sequence"), b"AA--"),
     /// ]);
-    /// let msa = Alignment::from_aligned(seqs, &tree).unwrap();
+    /// let msa = Alignment::from_aligned(seqs, &tree)?;
     /// assert_eq!(msa.len(), 4);
+    /// # Ok(()) }
     /// ```
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
@@ -101,14 +105,16 @@ impl Alignment {
     /// use phylo::alignment::Alignment;
     /// use phylo::alignment::Sequences;
     /// use phylo::{record, tree};
+    /// # fn main() -> std::result::Result<(), anyhow::Error> {
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
     /// let seqs = Sequences::new(vec![
     ///     record!("A0", Some("A0 sequence"), b"AAAA"),
     ///     record!("B1", Some("B1 sequence"), b"---A"),
     ///     record!("C2", Some("C2 sequence"), b"AA--"),
     /// ]);
-    /// let msa = Alignment::from_aligned(seqs, &tree).unwrap();
+    /// let msa = Alignment::from_aligned(seqs, &tree)?;
     /// assert_eq!(msa.seq_count(), 3);
+    /// # Ok(()) }
     /// ```
     pub fn seq_count(&self) -> usize {
         self.leaf_map.len()
@@ -122,15 +128,17 @@ impl Alignment {
     /// use phylo::alignment::Alignment;
     /// use phylo::alignment::Sequences;
     /// use phylo::{record, tree};
+    /// # fn main() -> std::result::Result<(), anyhow::Error> {
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
     /// let seqs = Sequences::new(vec![
     ///     record!("A0", Some("A0 sequence"), b"AAAA"),
     ///     record!("B1", Some("B1 sequence"), b"---A"),
     ///     record!("C2", Some("C2 sequence"), b"AA--"),
     /// ]);
-    /// let msa = Alignment::from_aligned(seqs.clone(), &tree).unwrap();
-    /// let aligned_seqs = msa.compile(&tree).unwrap();
+    /// let msa = Alignment::from_aligned(seqs.clone(), &tree)?;
+    /// let aligned_seqs = msa.compile(&tree)?;
     /// assert_eq!(aligned_seqs, seqs);
+    /// # Ok(()) }
     /// ```
     pub fn from_aligned(mut seqs: Sequences, tree: &Tree) -> Result<Alignment> {
         if !seqs.aligned {

--- a/phylo/src/io/mod.rs
+++ b/phylo/src/io/mod.rs
@@ -36,12 +36,14 @@ impl Error for DataError {}
 /// # Example
 /// ```
 /// use phylo::io::read_sequences;
-/// let records = read_sequences("./examples/data/sequences_DNA_small.fasta").unwrap();
-/// # assert_eq!(records.len(), 4);
-/// # for rec in records {
-/// #    assert_eq!(rec.seq().len(), 8);
-/// #    assert_eq!(rec.seq(), rec.seq().to_ascii_uppercase());
-/// # }
+/// # fn main() -> std::result::Result<(), anyhow::Error> {
+/// let records = read_sequences("./examples/data/sequences_DNA_small.fasta")?;
+/// assert_eq!(records.len(), 4);
+/// for rec in records {
+///    assert_eq!(rec.seq().len(), 8);
+///    assert_eq!(rec.seq(), rec.seq().to_ascii_uppercase());
+/// }
+/// # Ok(()) }
 /// ```
 pub fn read_sequences(path: impl AsRef<Path> + Debug) -> Result<Vec<Record>> {
     info!("Reading sequences from file {}", path.as_ref().display());
@@ -100,20 +102,20 @@ pub fn read_sequences(path: impl AsRef<Path> + Debug) -> Result<Vec<Record>> {
 ///
 /// use bio::io::fasta::Record;
 /// use phylo::io::write_sequences_to_file;
+/// # fn main() -> std::result::Result<(), anyhow::Error> {
 /// let sequences = vec![
 ///    Record::with_attrs("seq1", None, b"ATGC"),
 ///    Record::with_attrs("seq2", None, b"CGTA"),
 /// ];
 /// let output_path = "./examples/data/doctest_tmp_output.fasta";
-/// write_sequences_to_file(&sequences, output_path).unwrap();
+/// write_sequences_to_file(&sequences, output_path)?;
 /// # let mut file_content = String::new();
-/// # File::open(output_path)
-/// #   .unwrap()
-/// #   .read_to_string(&mut file_content)
-/// #   .unwrap();
+/// # File::open(output_path)?
+/// #   .read_to_string(&mut file_content)?;
 /// # let expected_output = ">seq1\nATGC\n>seq2\nCGTA\n";
 /// # assert_eq!(file_content, expected_output);
 /// # assert!(remove_file(output_path).is_ok());
+/// # Ok(()) }
 /// ```
 pub fn write_sequences_to_file(sequences: &[Record], path: impl AsRef<Path>) -> Result<()> {
     info!("Writing sequences/MSA to file {}", path.as_ref().display());
@@ -143,9 +145,11 @@ pub fn write_sequences_to_file(sequences: &[Record], path: impl AsRef<Path>) -> 
 /// # Example
 /// ```
 /// use phylo::io::read_newick_from_file;
-/// let trees = read_newick_from_file("./examples/data/tree.newick").unwrap();
-/// # assert_eq!(trees.len(), 1);
-/// # assert_eq!(trees[0].leaves().len(), 4);
+/// # fn main() -> std::result::Result<(), anyhow::Error> {
+/// let trees = read_newick_from_file("./examples/data/tree.newick")?;
+/// assert_eq!(trees.len(), 1);
+/// assert_eq!(trees[0].leaves().len(), 4);
+/// # Ok(()) }
 /// ```
 pub fn read_newick_from_file(path: impl AsRef<Path>) -> Result<Vec<Tree>> {
     info!("Reading newick trees from file {}", path.as_ref().display());
@@ -169,13 +173,15 @@ pub fn read_newick_from_file(path: impl AsRef<Path>) -> Result<Vec<Tree>> {
 /// use phylo::tree::Tree;
 /// use phylo::io::write_newick_to_file;
 ///
+/// # fn main() -> std::result::Result<(), anyhow::Error> {
 /// let output_path = "./examples/data/doctest_tmp_output.newick";
-/// let trees = from_newick("((A:1.0,B:2.0):1,(D:1.0,E:2.0):1):0.0;").unwrap();
-/// write_newick_to_file(&trees, output_path).unwrap();
+/// let trees = from_newick("((A:1.0,B:2.0):1,(D:1.0,E:2.0):1):0.0;")?;
+/// write_newick_to_file(&trees, output_path)?;
 /// # let mut file_content = String::new();
-/// # File::open(output_path).unwrap().read_to_string(&mut file_content).unwrap();
+/// # File::open(output_path)?.read_to_string(&mut file_content)?;
 /// # assert_eq!(file_content.trim(), "(((A:1,B:2):1,(D:1,E:2):1):0);");
 /// # assert!(remove_file(output_path).is_ok());
+/// # Ok(()) }
 /// ```
 pub fn write_newick_to_file(trees: &[Tree], path: impl AsRef<Path>) -> Result<()> {
     info!("Writing newick trees to file {}", path.as_ref().display());

--- a/phylo/src/phylo_info/mod.rs
+++ b/phylo/src/phylo_info/mod.rs
@@ -42,14 +42,15 @@ impl PhyloInfo {
     /// use phylo::frequencies;
     /// use phylo::phylo_info::PhyloInfoBuilder;
     /// use phylo::substitution_models::FreqVector;
+    /// # fn main() -> std::result::Result<(), anyhow::Error> {
     /// let info = PhyloInfoBuilder::with_attrs(
     ///     "./examples/data/sequences_DNA1.fasta",
     ///     "./examples/data/tree_diff_branch_lengths_2.newick")
-    /// .build()
-    /// .unwrap();
+    /// .build()?;
     /// let freqs = info.freqs();
     /// assert_eq!(freqs, frequencies!(&[1.25, 2.25, 4.25, 1.25]).scale(1.0 / 9.0));
     /// assert_eq!(freqs.sum(), 1.0);
+    /// # Ok(()) }
     /// ```
     pub fn freqs(&self) -> FreqVector {
         let alphabet = self.msa.alphabet();

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -88,8 +88,10 @@ impl PhyloInfoBuilder {
     /// ```
     /// use phylo::alphabets::protein_alphabet;
     /// use phylo::phylo_info::PhyloInfoBuilder;
-    /// let info = PhyloInfoBuilder::new("./examples/data/sequences_DNA_small.fasta").alphabet(Some(protein_alphabet())).build().unwrap();
+    /// # fn main() -> std::result::Result<(), anyhow::Error> {
+    /// let info = PhyloInfoBuilder::new("./examples/data/sequences_DNA_small.fasta").alphabet(Some(protein_alphabet())).build()?;
     /// assert_eq!(info.msa.alphabet(), &protein_alphabet());
+    /// # Ok(()) }
     /// ```
     pub fn alphabet(mut self, alphabet: Option<Alphabet>) -> PhyloInfoBuilder {
         self.alphabet = alphabet;
@@ -107,15 +109,16 @@ impl PhyloInfoBuilder {
     /// # Example
     /// ```
     /// use phylo::phylo_info::PhyloInfoBuilder;
+    /// # fn main() -> std::result::Result<(), anyhow::Error> {
     /// let info = PhyloInfoBuilder::with_attrs(
     ///     "./examples/data/sequences_DNA_small.fasta",
     ///     "./examples/data/tree_diff_branch_lengths_2.newick")
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
     /// assert_eq!(info.msa.len(), 8);
     /// assert_eq!(info.msa.seq_count(), 4);
     /// assert_eq!(info.tree.leaves().len(), 4);
     /// assert_eq!(info.tree.len(), 7);
+    /// # Ok(()) }
     /// ```
     pub fn build(self) -> Result<PhyloInfo> {
         info!(


### PR DESCRIPTION
Replaced all instances of unwrap() in doctests with ? as described in [rust api guidelines](https://rust-lang.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark). To do that added an invisible main fn:
`fn main() -> std::result::Result<(), anyhow::Error> {` to allow ? to work.