### PR TITLE
Sort/reformat use statements to guidelines

### DIFF
--- a/phylo/benches/cost.rs
+++ b/phylo/benches/cost.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use phylo::{
-    evolutionary_models::FrequencyOptimisation,
-    likelihood::ModelSearchCost,
-    pip_model::PIPCost,
-    substitution_models::{QMatrix, QMatrixMaker, JC69, WAG},
-};
+
+use phylo::evolutionary_models::FrequencyOptimisation;
+use phylo::likelihood::ModelSearchCost;
+use phylo::pip_model::PIPCost;
+use phylo::substitution_models::{QMatrix, QMatrixMaker, JC69, WAG};
+
 mod helpers;
 use helpers::{
     black_box_pip_cost, SequencePaths, AA_EASY_12X73, AA_EASY_14X165, AA_EASY_27X632,

--- a/phylo/benches/helpers.rs
+++ b/phylo/benches/helpers.rs
@@ -4,13 +4,12 @@
 use std::{collections::HashMap, hint::black_box, path::PathBuf, time::Duration};
 
 use criterion::Criterion;
-use phylo::{
-    evolutionary_models::FrequencyOptimisation,
-    optimisers::ModelOptimiser,
-    phylo_info::{PhyloInfo, PhyloInfoBuilder},
-    pip_model::{PIPCost, PIPCostBuilder, PIPModel},
-    substitution_models::{QMatrix, QMatrixMaker},
-};
+
+use phylo::evolutionary_models::FrequencyOptimisation;
+use phylo::optimisers::ModelOptimiser;
+use phylo::phylo_info::{PhyloInfo, PhyloInfoBuilder};
+use phylo::pip_model::{PIPCost, PIPCostBuilder, PIPModel};
+use phylo::substitution_models::{QMatrix, QMatrixMaker};
 
 pub type BenchPath = &'static str;
 pub type SequencePaths = HashMap<&'static str, BenchPath>;

--- a/phylo/benches/spr.rs
+++ b/phylo/benches/spr.rs
@@ -9,6 +9,7 @@ use phylo::optimisers::{spr, RegraftOptimiser};
 use phylo::pip_model::PIPCost;
 use phylo::substitution_models::{QMatrix, QMatrixMaker, JC69, WAG};
 use phylo::tree::NodeIdx;
+
 mod helpers;
 use helpers::{
     black_box_pip_cost, SequencePaths, AA_EASY_12X73, AA_EASY_27X632, AA_EASY_6X97,

--- a/phylo/benches/topo.rs
+++ b/phylo/benches/topo.rs
@@ -8,6 +8,7 @@ use phylo::likelihood::TreeSearchCost;
 use phylo::optimisers::{TopologyOptimiser, TopologyOptimiserPredicate};
 use phylo::pip_model::PIPCost;
 use phylo::substitution_models::{QMatrix, QMatrixMaker, JC69, WAG};
+
 mod helpers;
 use helpers::{
     black_box_pip_cost, SequencePaths, AA_EASY_12X73, AA_EASY_6X97, DNA_EASY_5X1000,

--- a/phylo/benches/tree_from_msa.rs
+++ b/phylo/benches/tree_from_msa.rs
@@ -3,7 +3,6 @@ use std::result::Result::Ok;
 use std::time::Duration;
 
 use anyhow::Result;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 use log::info;
 
@@ -13,6 +12,7 @@ use phylo::optimisers::{ModelOptimiser, TopologyOptimiser};
 use phylo::pip_model::PIPCost;
 use phylo::substitution_models::{QMatrix, QMatrixMaker, JC69, WAG};
 use phylo::tree::Tree;
+
 mod helpers;
 use helpers::{
     black_box_raw_pip_cost_with_config, PIPConfig, SequencePaths, AA_EASY_12X73, AA_EASY_6X97,

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -49,9 +49,7 @@ impl Alignment {
     ///
     /// # Example
     /// ```
-    /// # use bio::io::fasta::Record;
-    /// use phylo::alignment::Alignment;
-    /// use phylo::alignment::Sequences;
+    /// use phylo::alignment::{Alignment, Sequences};
     /// use phylo::alphabets::dna_alphabet;
     /// use phylo::{record, tree};
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
@@ -71,9 +69,7 @@ impl Alignment {
     ///
     /// # Example
     /// ```
-    /// # use bio::io::fasta::Record;
-    /// use phylo::alignment::Alignment;
-    /// use phylo::alignment::Sequences;
+    /// use phylo::alignment::{Alignment, Sequences};
     /// use phylo::{record, tree};
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
     /// let seqs = Sequences::new(vec![
@@ -97,9 +93,7 @@ impl Alignment {
     ///
     /// # Example
     /// ```
-    /// # use bio::io::fasta::Record;
-    /// use phylo::alignment::Alignment;
-    /// use phylo::alignment::Sequences;
+    /// use phylo::alignment::{Alignment, Sequences};
     /// use phylo::{record, tree};
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
     /// let seqs = Sequences::new(vec![
@@ -118,9 +112,7 @@ impl Alignment {
     ///
     /// # Example
     /// ```
-    /// # use bio::io::fasta::Record;
-    /// use phylo::alignment::Alignment;
-    /// use phylo::alignment::Sequences;
+    /// use phylo::alignment::{Alignment, Sequences};
     /// use phylo::{record, tree};
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
     /// let seqs = Sequences::new(vec![

--- a/phylo/src/alphabets/parsimony_set.rs
+++ b/phylo/src/alphabets/parsimony_set.rs
@@ -1,5 +1,5 @@
-use std::ops::{BitAnd, BitOr, Sub};
-use std::{fmt::Display, ops::Deref};
+use std::fmt::Display;
+use std::ops::{BitAnd, BitOr, Deref, Sub};
 
 use hashbrown::{hash_set::IntoIter, HashSet};
 use itertools::join;

--- a/phylo/src/alphabets/tests.rs
+++ b/phylo/src/alphabets/tests.rs
@@ -1,10 +1,10 @@
+use bio::io::fasta::Record;
 use rstest::*;
 
-use bio::io::fasta::Record;
-
-use crate::alphabets::{dna_alphabet, protein_alphabet, ParsimonySet};
-
-use super::{AMB_AMINOACIDS, AMB_NUCLEOTIDES, AMINOACIDS, NUCLEOTIDES};
+use crate::alphabets::{
+    dna_alphabet, protein_alphabet, ParsimonySet, AMB_AMINOACIDS, AMB_NUCLEOTIDES, AMINOACIDS,
+    NUCLEOTIDES,
+};
 
 #[test]
 fn parsimony_set_iters() {

--- a/phylo/src/io/tests.rs
+++ b/phylo/src/io/tests.rs
@@ -1,8 +1,7 @@
-use rstest::*;
-
 use std::fs::File;
 use std::io::Read;
 
+use rstest::*;
 use tempfile::tempdir;
 
 use crate::io::{read_sequences, write_newick_to_file, write_sequences_to_file};

--- a/phylo/src/optimisers/model_optimiser.rs
+++ b/phylo/src/optimisers/model_optimiser.rs
@@ -7,10 +7,8 @@ use log::{debug, info, warn};
 
 use crate::evolutionary_models::FrequencyOptimisation;
 use crate::likelihood::ModelSearchCost;
-use crate::optimisers::ModelOptimisationResult;
+use crate::optimisers::{ModelOptimisationResult, SingleValOptResult};
 use crate::Result;
-
-use super::SingleValOptResult;
 
 pub struct ModelOptimiser<C: ModelSearchCost + Display> {
     pub(crate) epsilon: f64,

--- a/phylo/src/optimisers/topo_optimiser.rs
+++ b/phylo/src/optimisers/topo_optimiser.rs
@@ -152,7 +152,10 @@ pub mod spr {
     use itertools::Itertools;
     use log::info;
 
-    use crate::{likelihood::TreeSearchCost, optimisers::RegraftOptimiser, tree::NodeIdx, Result};
+    use crate::likelihood::TreeSearchCost;
+    use crate::optimisers::RegraftOptimiser;
+    use crate::tree::NodeIdx;
+    use crate::Result;
 
     /// Iterates over `prune_locations` in order and applies the best (improving)
     /// SPR move for each pruneing location in place

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -8,11 +8,9 @@ use crate::likelihood::TreeSearchCost;
 use crate::optimisers::{
     BranchOptimiser, ModelOptimiser, PhyloOptimisationResult, TopologyOptimiser,
 };
-use crate::parsimony::scoring::ModelScoringBuilder;
-use crate::parsimony::{BasicParsimonyCost, DolloParsimonyCost};
+use crate::parsimony::{scoring::ModelScoringBuilder, BasicParsimonyCost, DolloParsimonyCost};
 use crate::phylo_info::{PhyloInfo, PhyloInfoBuilder as PIB};
-use crate::pip_model::PIPCost;
-use crate::pip_model::{PIPCostBuilder as PIPCB, PIPModel};
+use crate::pip_model::{PIPCost, PIPCostBuilder as PIPCB, PIPModel};
 use crate::substitution_models::{
     dna_models::*, protein_models::*, QMatrix, SubstModel, SubstitutionCost,
     SubstitutionCostBuilder as SCB,

--- a/phylo/src/parsimony/cost/basic_parsimony_cost.rs
+++ b/phylo/src/parsimony/cost/basic_parsimony_cost.rs
@@ -1,8 +1,6 @@
 use std::cell::RefCell;
 use std::fmt::Display;
 
-use anyhow::Ok;
-
 use crate::alphabets::ParsimonySet;
 use crate::likelihood::TreeSearchCost;
 use crate::phylo_info::PhyloInfo;
@@ -152,9 +150,8 @@ impl BasicParsimonyInfo {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod private_tests {
-    use super::*;
-
     use crate::alignment::{Alignment, Sequences};
+    use crate::parsimony::BasicParsimonyCost;
     use crate::phylo_info::PhyloInfo;
     use crate::{record_wo_desc as record, tree};
 

--- a/phylo/src/parsimony/cost/dollo_parsimony_cost.rs
+++ b/phylo/src/parsimony/cost/dollo_parsimony_cost.rs
@@ -6,8 +6,10 @@ use hashbrown::HashSet;
 
 use crate::alphabets::ParsimonySet;
 use crate::likelihood::TreeSearchCost;
-use crate::parsimony::scoring::{GapCost, SimpleScoring};
-use crate::parsimony::ParsimonyScoring;
+use crate::parsimony::{
+    scoring::{GapCost, SimpleScoring},
+    ParsimonyScoring,
+};
 use crate::phylo_info::PhyloInfo;
 use crate::tree::{
     NodeIdx::{self, Internal, Leaf},
@@ -232,9 +234,9 @@ impl DolloParsimonyInfo {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod private_tests {
-    use super::*;
-
     use crate::alignment::{Alignment, Sequences};
+    use crate::likelihood::TreeSearchCost;
+    use crate::parsimony::{DolloParsimonyCost, GapCost, SimpleScoring};
     use crate::phylo_info::PhyloInfo;
     use crate::{record_wo_desc as record, tree};
 

--- a/phylo/src/parsimony/cost/tests.rs
+++ b/phylo/src/parsimony/cost/tests.rs
@@ -1,7 +1,9 @@
 use crate::alignment::{Alignment, Sequences};
 use crate::likelihood::TreeSearchCost;
-use crate::parsimony::scoring::{GapCost, ModelScoringBuilder, SimpleScoring};
-use crate::parsimony::{BasicParsimonyCost, DolloParsimonyCost};
+use crate::parsimony::{
+    scoring::{GapCost, ModelScoringBuilder, SimpleScoring},
+    BasicParsimonyCost, DolloParsimonyCost,
+};
 use crate::phylo_info::PhyloInfo;
 use crate::substitution_models::{SubstModel, WAG};
 use crate::{record_wo_desc as rec, tree};

--- a/phylo/src/parsimony/matrices/mod.rs
+++ b/phylo/src/parsimony/matrices/mod.rs
@@ -3,7 +3,7 @@ use std::{fmt, iter::zip};
 use crate::alignment::{Mapping, PairwiseAlignment};
 use crate::alphabets::ParsimonySet;
 use crate::parsimony::{
-    Direction::{self, GapInX, GapInY, Matc},
+    Direction::{self, *},
     ParsimonyScoring, ParsimonySite,
     SiteFlag::{self, *},
 };

--- a/phylo/src/parsimony/matrices/tests.rs
+++ b/phylo/src/parsimony/matrices/tests.rs
@@ -1,6 +1,6 @@
 use approx::assert_relative_eq;
 
-use crate::parsimony::matrices::Direction::{GapInX, GapInY, Matc};
+use crate::parsimony::matrices::Direction::*;
 use crate::parsimony::scoring::{GapCost as GC, ModelScoringBuilder as MCB, SimpleScoring};
 use crate::parsimony::{ParsimonyAlignmentMatrices as PAM, ParsimonySite, SiteFlag::*};
 use crate::substitution_models::{SubstModel, K80};

--- a/phylo/src/parsimony/mod.rs
+++ b/phylo/src/parsimony/mod.rs
@@ -8,7 +8,10 @@ use nalgebra::DMatrix;
 use crate::alignment::{Aligner, Alignment, InternalMapping, PairwiseAlignment, Sequences};
 use crate::alphabets::ParsimonySet;
 use crate::evolutionary_models::EvoModel;
-use crate::tree::{NodeIdx::Internal as Int, NodeIdx::Leaf, Tree};
+use crate::tree::{
+    NodeIdx::{Internal as Int, Leaf},
+    Tree,
+};
 use crate::Result;
 
 pub mod cost;

--- a/phylo/src/parsimony/scoring/mod.rs
+++ b/phylo/src/parsimony/scoring/mod.rs
@@ -3,12 +3,12 @@ use std::ops::Mul;
 
 use dyn_clone::DynClone;
 
+use crate::alphabets::ParsimonySet;
+
 pub mod model_scoring;
 pub use model_scoring::*;
 pub mod simple_scoring;
 pub use simple_scoring::*;
-
-use crate::alphabets::ParsimonySet;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GapCost {

--- a/phylo/src/parsimony/scoring/model_scoring.rs
+++ b/phylo/src/parsimony/scoring/model_scoring.rs
@@ -177,11 +177,13 @@ mod private_tests {
     use std::fmt::Debug;
 
     use approx::assert_relative_eq;
+    use ordered_float::OrderedFloat;
 
+    use crate::parsimony::{
+        CostMatrix, DiagonalZeros as Z, GapCost, ModelScoringBuilder, ModelScoringBuilder as MCB,
+        ParsimonyModel, ParsimonyScoring, Rounding as R,
+    };
     use crate::substitution_models::*;
-
-    use super::*;
-    use super::{DiagonalZeros as Z, ModelScoringBuilder as MCB, Rounding as R};
 
     const TRUE_COST_MATRIX: [f64; 400] = [
         0.0, 6.0, 6.0, 5.0, 6.0, 6.0, 5.0, 4.0, 7.0, 7.0, 6.0, 5.0, 6.0, 7.0, 5.0, 4.0, 4.0, 9.0,

--- a/phylo/src/parsimony/scoring/simple_scoring.rs
+++ b/phylo/src/parsimony/scoring/simple_scoring.rs
@@ -1,9 +1,7 @@
 use std::fmt::Display;
 
-use crate::{
-    alphabets::ParsimonySet,
-    parsimony::{GapCost, ParsimonyScoring},
-};
+use crate::alphabets::ParsimonySet;
+use crate::parsimony::{GapCost, ParsimonyScoring};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SimpleScoring {

--- a/phylo/src/parsimony/scoring/tests.rs
+++ b/phylo/src/parsimony/scoring/tests.rs
@@ -1,15 +1,12 @@
-use rstest::rstest;
-
 use approx::assert_relative_eq;
+use rstest::rstest;
 
 use crate::alphabets::{ParsimonySet, AMINOACIDS, NUCLEOTIDES};
 use crate::parsimony::{
     DiagonalZeros as Z, GapCost, ModelScoringBuilder as MCB, ParsimonyScoring, Rounding as R,
     SimpleScoring,
 };
-use crate::substitution_models::{
-    QMatrix, QMatrixMaker, SubstModel, BLOSUM, GTR, HIVB, HKY, JC69, K80, TN93, WAG,
-};
+use crate::substitution_models::*;
 
 #[test]
 fn default_costs() {

--- a/phylo/src/parsimony/tests.rs
+++ b/phylo/src/parsimony/tests.rs
@@ -1,9 +1,5 @@
 use crate::alignment::Sequences;
-
-use crate::parsimony::{
-    GapCost, ParsimonyAligner, ParsimonySite, SimpleScoring,
-    SiteFlag::{GapExt, GapOpen, NoGap},
-};
+use crate::parsimony::{GapCost, ParsimonyAligner, ParsimonySite, SimpleScoring, SiteFlag::*};
 use crate::{record_wo_desc as rec, site, test_align as align, tree};
 
 #[test]

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -13,7 +13,6 @@ use crate::pip_model::{PIPCostBuilder as PIPB, PIPModel, PIPModelInfo};
 use crate::substitution_models::{
     dna_models::*, protein_models::*, FreqVector, QMatrix, QMatrixMaker, SubstMatrix, SubstModel,
 };
-
 use crate::{frequencies, record_wo_desc as record, tree};
 
 const UNNORMALIZED_PIP_HKY_Q: [f64; 25] = [

--- a/phylo/src/tree/nj_matrices.rs
+++ b/phylo/src/tree/nj_matrices.rs
@@ -1,6 +1,8 @@
-use crate::tree::NodeIdx::{self, Internal as Int};
-use nalgebra::{max, min, DMatrix};
 use std::fmt::{Display, Formatter, Result};
+
+use nalgebra::{max, min, DMatrix};
+
+use crate::tree::NodeIdx::{self, Internal as Int};
 
 pub(super) type Mat = DMatrix<f64>;
 


### PR DESCRIPTION
Sorted and reformatted use statements throughout the project to follow a standard ordering of use groups:
```
use std::anything;

use non-std::anything;
use another-non-std::whatever;

use crate::something;
use crate::another_something;
```