### PR TITLE
Release prep/macro use everywhere

### DIFF
--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -1,12 +1,11 @@
 use std::fmt::Display;
 
 use anyhow::bail;
-use bio::io::fasta::Record;
 use hashbrown::HashMap;
 
 use crate::alphabets::{Alphabet, GAP};
 use crate::tree::{NodeIdx, NodeIdx::Internal as Int, NodeIdx::Leaf, Tree};
-use crate::{align, Result};
+use crate::{align, record, Result};
 
 pub mod sequences;
 pub use sequences::*;
@@ -195,7 +194,7 @@ impl Alignment {
         for (idx, map) in &map {
             let rec = self.seqs.record_by_id(tree.node_id(idx));
             let aligned_seq = Self::map_sequence(map, rec.seq());
-            records.push(Record::with_attrs(rec.id(), rec.desc(), &aligned_seq));
+            records.push(record!(rec.id(), rec.desc(), &aligned_seq));
         }
 
         Ok(Sequences::with_alphabet(records, self.seqs.alphabet))

--- a/phylo/src/alignment/sequences.rs
+++ b/phylo/src/alignment/sequences.rs
@@ -5,7 +5,7 @@ use bio::io::fasta::Record;
 use bitvec::vec::BitVec;
 
 use crate::alphabets::{dna_alphabet, protein_alphabet, Alphabet, GAP};
-use crate::Result;
+use crate::{record, Result};
 
 #[derive(Debug, Clone)]
 pub struct Sequences {
@@ -120,7 +120,7 @@ impl Sequences {
                     .filter(|&c| c != &GAP)
                     .copied()
                     .collect::<Vec<u8>>();
-                Record::with_attrs(rec.id(), rec.desc(), &sequence)
+                record!(rec.id(), rec.desc(), &sequence)
             })
             .collect();
         Sequences {
@@ -151,7 +151,7 @@ impl Sequences {
                 .filter(|(i, _)| !gap_cols[*i])
                 .map(|(_, c)| *c)
                 .collect();
-            Record::with_attrs(rec.id(), rec.desc(), &seq)
+            record!(rec.id(), rec.desc(), &seq)
         });
         self.s = new_seqs.collect();
     }

--- a/phylo/src/alphabets/tests.rs
+++ b/phylo/src/alphabets/tests.rs
@@ -1,10 +1,10 @@
-use bio::io::fasta::Record;
 use rstest::*;
 
 use crate::alphabets::{
     dna_alphabet, protein_alphabet, ParsimonySet, AMB_AMINOACIDS, AMB_NUCLEOTIDES, AMINOACIDS,
     NUCLEOTIDES,
 };
+use crate::record_wo_desc as record;
 
 #[test]
 fn parsimony_set_iters() {
@@ -23,7 +23,7 @@ fn parsimony_set_iters() {
 
 #[test]
 fn dna_sets() {
-    let record = Record::with_attrs("", None, b"AaCcTtGgXn-");
+    let record = record!("", b"AaCcTtGgXn-");
 
     let sets = record
         .seq()
@@ -45,7 +45,7 @@ fn dna_sets() {
 
 #[test]
 fn protein_sets() {
-    let record = Record::with_attrs("", None, b"rRlLeEqQxO-");
+    let record = record!("", b"rRlLeEqQxO-");
     let sets = record
         .seq()
         .iter()

--- a/phylo/src/io/mod.rs
+++ b/phylo/src/io/mod.rs
@@ -10,7 +10,7 @@ use log::info;
 
 use crate::alphabets::{protein_alphabet, GAP, POSSIBLE_GAPS};
 use crate::tree::{tree_parser, Tree};
-use crate::Result;
+use crate::{record, Result};
 
 pub(crate) struct DataError {
     pub(crate) message: String,
@@ -73,7 +73,7 @@ pub fn read_sequences(path: impl AsRef<Path> + Debug) -> Result<Vec<Record>> {
             });
         }
 
-        sequences.push(Record::with_attrs(rec.id(), rec.desc(), &seq));
+        sequences.push(record!(rec.id(), rec.desc(), &seq));
     }
     if sequences.is_empty() {
         bail!(DataError {
@@ -100,12 +100,12 @@ pub fn read_sequences(path: impl AsRef<Path> + Debug) -> Result<Vec<Record>> {
 ///
 /// use std::fs::{File, remove_file};
 ///
-/// use bio::io::fasta::Record;
 /// use phylo::io::write_sequences_to_file;
+/// use phylo::record;
 /// # fn main() -> std::result::Result<(), anyhow::Error> {
 /// let sequences = vec![
-///    Record::with_attrs("seq1", None, b"ATGC"),
-///    Record::with_attrs("seq2", None, b"CGTA"),
+///    record!("seq1", None, b"ATGC"),
+///    record!("seq2", None, b"CGTA"),
 /// ];
 /// let output_path = "./examples/data/doctest_tmp_output.fasta";
 /// write_sequences_to_file(&sequences, output_path)?;

--- a/phylo/src/macros.rs
+++ b/phylo/src/macros.rs
@@ -42,6 +42,7 @@ macro_rules! record {
 }
 
 /// Create a tree from a Newick string.
+/// Warning: this macro creates a tree with no checks on the Newick format.
 ///
 /// # Examples
 /// ```


### PR DESCRIPTION
Using `record!` macro wherever `bio::io::fasta::Record` is being created + a warning for the `tree!` macro because it does not check newick validity.