### PR TITLE
Enhancement/cost cache valid tests

### DIFF
--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -858,9 +858,7 @@ fn blen_leading_to_minusinf() {
 }
 
 #[cfg(test)]
-fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
-    use crate::likelihood::TreeSearchCost;
-
+fn setup_test_info(alphabet: Alphabet) -> PhyloInfo<MSA> {
     let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
     let msa = MSA::from_aligned(
         Sequences::with_alphabet(
@@ -875,7 +873,14 @@ fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet
         &tree,
     )
     .unwrap();
-    let info = PhyloInfo { msa, tree };
+    PhyloInfo { msa, tree }
+}
+
+#[cfg(test)]
+fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+    use crate::likelihood::TreeSearchCost;
+
+    let info = setup_test_info(alphabet);
 
     let model = PIPModel::<Q>::new(&[], &[]);
     let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
@@ -912,33 +917,17 @@ fn dirty_tree_costs_match() {
 fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
     use crate::likelihood::TreeSearchCost;
 
-    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
-    let msa = MSA::from_aligned(
-        Sequences::with_alphabet(
-            vec![
-                record!("A", b"CT-ATA-TA-TAC"),
-                record!("B", b"ATATA--TATA-A"),
-                record!("C", b"TTA--TATATA-T"),
-                record!("D", b"TTA--TATATA-T"),
-            ],
-            alphabet,
-        ),
-        &tree,
-    )
-    .unwrap();
-    let info = PhyloInfo {
-        msa: msa.clone(),
-        tree: tree.clone(),
-    };
+    let info = setup_test_info(alphabet);
 
     let model = PIPModel::<Q>::new(&[], &[]);
-    let mut c = PIPB::new(model.clone(), info).build().unwrap();
+    let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
     let logl = TreeSearchCost::cost(&c);
 
     // The likelihood should change if we change branch lengths
-    let mut mutated_tree = tree.clone();
-    mutated_tree.set_blen(&tree.by_id("F").idx, 4.0);
-    mutated_tree.set_blen(&tree.by_id("B").idx, 0.75);
+    let mut mutated_tree = info.tree.clone();
+
+    mutated_tree.set_blen(&info.tree.by_id("F").idx, 4.0);
+    mutated_tree.set_blen(&info.tree.by_id("B").idx, 0.75);
     c.update_tree(mutated_tree);
 
     let logl2 = TreeSearchCost::cost(&c);
@@ -948,7 +937,7 @@ fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphab
     // The likelihood should be the same if we rebuild from scratch with the same modification
     let new_tree = tree!("(((A:1.0,B:0.75)E:2.0,(C:1.0,D:1.0)F:4.0)G:3.0);");
     let new_info = PhyloInfo {
-        msa,
+        msa: info.msa.clone(),
         tree: new_tree,
     };
     let c = PIPB::new(model, new_info).build().unwrap();
@@ -972,24 +961,7 @@ fn dirty_branch_costs_match() {
 
 #[cfg(test)]
 fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
-    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
-    let msa = MSA::from_aligned(
-        Sequences::with_alphabet(
-            vec![
-                record!("A", b"CT-ATA-TA-TAC"),
-                record!("B", b"ATATA--TATA-A"),
-                record!("C", b"TTA--TATATA-T"),
-                record!("D", b"TTA--TATATA-T"),
-            ],
-            alphabet,
-        ),
-        &tree,
-    )
-    .unwrap();
-    let info = PhyloInfo {
-        msa: msa.clone(),
-        tree: tree.clone(),
-    };
+    let info = setup_test_info(alphabet);
 
     let model = PIPModel::<Q>::new(&[], &[1.0]);
     let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
@@ -1024,24 +996,7 @@ fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
     alphabet: Alphabet,
     freqs: FreqVector,
 ) {
-    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
-    let msa = MSA::from_aligned(
-        Sequences::with_alphabet(
-            vec![
-                record!("A", b"CT-ATA-TA-TAC"),
-                record!("B", b"ATATA--TATA-A"),
-                record!("C", b"TTA--TATATA-T"),
-                record!("D", b"TTA--TATATA-T"),
-            ],
-            alphabet,
-        ),
-        &tree,
-    )
-    .unwrap();
-    let info = PhyloInfo {
-        msa: msa.clone(),
-        tree: tree.clone(),
-    };
+    let info = setup_test_info(alphabet);
 
     let model = PIPModel::<Q>::new(&[], &[]);
     let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -4,7 +4,9 @@ use approx::assert_relative_eq;
 use nalgebra::{DMatrix, DVector};
 
 use crate::alignment::{Alignment, Sequences, MSA};
-use crate::alphabets::{protein_alphabet, AMINOACIDS as aas, GAP, NUCLEOTIDES as nucls};
+use crate::alphabets::{
+    dna_alphabet, protein_alphabet, Alphabet, AMINOACIDS as aas, GAP, NUCLEOTIDES as nucls,
+};
 use crate::evolutionary_models::EvoModel;
 use crate::io::read_sequences;
 use crate::likelihood::ModelSearchCost;
@@ -853,4 +855,117 @@ fn blen_leading_to_minusinf() {
     let logl = c.cost();
     assert_ne!(logl, f64::NEG_INFINITY);
     assert!(logl.is_sign_negative());
+}
+
+#[cfg(test)]
+fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+    use crate::likelihood::TreeSearchCost;
+
+    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(
+            vec![
+                record!("A", b"CT-ATA-TA-TAC"),
+                record!("B", b"ATATA--TATA-A"),
+                record!("C", b"TTA--TATATA-T"),
+                record!("D", b"TTA--TATATA-T"),
+            ],
+            alphabet,
+        ),
+        &tree,
+    )
+    .unwrap();
+    let info = PhyloInfo { msa, tree };
+
+    let model = PIPModel::<Q>::new(&[], &[]);
+    let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
+    let logl = TreeSearchCost::cost(&c);
+    assert_eq!(logl, TreeSearchCost::cost(&c));
+
+    // The likelihood should be the same if we make the tree dirty without changing it
+    let mut tree = c.info.tree.clone();
+    tree.dirty();
+    c.update_tree(tree);
+    assert_eq!(logl, TreeSearchCost::cost(&c));
+
+    // The likelihood should be the same if we rebuild from scratch
+    let c2 = PIPB::new(model, info).build().unwrap();
+    let logl2 = TreeSearchCost::cost(&c2);
+    assert_eq!(logl2, TreeSearchCost::cost(&c2));
+    assert_eq!(logl, logl2);
+}
+
+#[test]
+fn dirty_tree_costs_match() {
+    dirty_tree_costs_match_template::<JC69>(dna_alphabet());
+    dirty_tree_costs_match_template::<K80>(dna_alphabet());
+    dirty_tree_costs_match_template::<HKY>(dna_alphabet());
+    dirty_tree_costs_match_template::<TN93>(dna_alphabet());
+    dirty_tree_costs_match_template::<GTR>(dna_alphabet());
+
+    dirty_tree_costs_match_template::<WAG>(protein_alphabet());
+    dirty_tree_costs_match_template::<HIVB>(protein_alphabet());
+    dirty_tree_costs_match_template::<BLOSUM>(protein_alphabet());
+}
+
+#[cfg(test)]
+fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+    use crate::likelihood::TreeSearchCost;
+
+    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(
+            vec![
+                record!("A", b"CT-ATA-TA-TAC"),
+                record!("B", b"ATATA--TATA-A"),
+                record!("C", b"TTA--TATATA-T"),
+                record!("D", b"TTA--TATATA-T"),
+            ],
+            alphabet,
+        ),
+        &tree,
+    )
+    .unwrap();
+    let info = PhyloInfo {
+        msa: msa.clone(),
+        tree: tree.clone(),
+    };
+
+    let model = PIPModel::<Q>::new(&[], &[]);
+    let mut c = PIPB::new(model.clone(), info).build().unwrap();
+    let logl = TreeSearchCost::cost(&c);
+
+    // The likelihood should change if we change branch lengths
+    let mut mutated_tree = tree.clone();
+    mutated_tree.set_blen(&tree.by_id("F").idx, 4.0);
+    mutated_tree.set_blen(&tree.by_id("B").idx, 0.75);
+    c.update_tree(mutated_tree);
+
+    let logl2 = TreeSearchCost::cost(&c);
+    assert_eq!(logl2, TreeSearchCost::cost(&c));
+    assert_ne!(logl, logl2);
+
+    // The likelihood should be the same if we rebuild from scratch with the same modification
+    let new_tree = tree!("(((A:1.0,B:0.75)E:2.0,(C:1.0,D:1.0)F:4.0)G:3.0);");
+    let new_info = PhyloInfo {
+        msa,
+        tree: new_tree,
+    };
+    let c = PIPB::new(model, new_info).build().unwrap();
+    let new_logl = TreeSearchCost::cost(&c);
+    assert_eq!(new_logl, TreeSearchCost::cost(&c));
+    assert_eq!(logl2, new_logl);
+}
+
+#[test]
+fn dirty_branch_costs_match() {
+    dirty_branch_costs_match_template::<JC69>(dna_alphabet());
+    dirty_branch_costs_match_template::<K80>(dna_alphabet());
+    dirty_branch_costs_match_template::<HKY>(dna_alphabet());
+    dirty_branch_costs_match_template::<TN93>(dna_alphabet());
+    dirty_branch_costs_match_template::<GTR>(dna_alphabet());
+
+    dirty_branch_costs_match_template::<WAG>(protein_alphabet());
+    dirty_branch_costs_match_template::<HIVB>(protein_alphabet());
+    dirty_branch_costs_match_template::<BLOSUM>(protein_alphabet());
 }

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -969,3 +969,109 @@ fn dirty_branch_costs_match() {
     dirty_branch_costs_match_template::<HIVB>(protein_alphabet());
     dirty_branch_costs_match_template::<BLOSUM>(protein_alphabet());
 }
+
+#[cfg(test)]
+fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(
+            vec![
+                record!("A", b"CT-ATA-TA-TAC"),
+                record!("B", b"ATATA--TATA-A"),
+                record!("C", b"TTA--TATATA-T"),
+                record!("D", b"TTA--TATATA-T"),
+            ],
+            alphabet,
+        ),
+        &tree,
+    )
+    .unwrap();
+    let info = PhyloInfo {
+        msa: msa.clone(),
+        tree: tree.clone(),
+    };
+
+    let model = PIPModel::<Q>::new(&[], &[1.0]);
+    let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
+    let logl = c.cost();
+
+    // The likelihood should change if we change model parameters
+    c.set_param(0, 0.5);
+
+    let logl2 = c.cost();
+    assert_eq!(logl2, c.cost());
+    assert_ne!(logl, logl2);
+
+    // The likelihood should be the same if we rebuild from scratch with the same modification
+    let new_model = PIPModel::<Q>::new(&[], &[0.5]);
+    let c = PIPB::new(new_model, info).build().unwrap();
+    let new_logl = c.cost();
+    assert_eq!(new_logl, c.cost());
+    assert_eq!(logl2, new_logl);
+}
+
+#[test]
+fn modify_model_params_costs_match() {
+    // does not apply to JC69, WAG, HIVB, BLOSUM which have no params
+    modify_model_params_costs_match_template::<K80>(dna_alphabet());
+    modify_model_params_costs_match_template::<HKY>(dna_alphabet());
+    modify_model_params_costs_match_template::<TN93>(dna_alphabet());
+    modify_model_params_costs_match_template::<GTR>(dna_alphabet());
+}
+
+#[cfg(test)]
+fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
+    alphabet: Alphabet,
+    freqs: FreqVector,
+) {
+    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(
+            vec![
+                record!("A", b"CT-ATA-TA-TAC"),
+                record!("B", b"ATATA--TATA-A"),
+                record!("C", b"TTA--TATATA-T"),
+                record!("D", b"TTA--TATATA-T"),
+            ],
+            alphabet,
+        ),
+        &tree,
+    )
+    .unwrap();
+    let info = PhyloInfo {
+        msa: msa.clone(),
+        tree: tree.clone(),
+    };
+
+    let model = PIPModel::<Q>::new(&[], &[]);
+    let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
+    let logl = c.cost();
+
+    // The likelihood should change if we change model frequencies
+    c.set_freqs(freqs.clone());
+
+    let logl2 = c.cost();
+    assert_eq!(logl2, c.cost());
+    assert_ne!(logl, logl2);
+
+    // The likelihood should be the same if we rebuild from scratch with the same modification
+    let new_model = PIPModel::<Q>::new(freqs.as_slice(), &[]);
+    let c = PIPB::new(new_model, info).build().unwrap();
+    let new_logl = c.cost();
+    assert_eq!(new_logl, c.cost());
+    assert_eq!(logl2, new_logl);
+}
+
+#[test]
+fn modify_model_freqs_costs_match() {
+    // does not apply to JC69 and K80 which have no freqs
+    let new_dna_freqs = frequencies!(&[0.1, 0.1, 0.1, 0.7]);
+    modify_model_freqs_costs_match_template::<HKY>(dna_alphabet(), new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<TN93>(dna_alphabet(), new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<GTR>(dna_alphabet(), new_dna_freqs);
+
+    let new_aa_freqs = frequencies!(&[0.05; 20]);
+    modify_model_freqs_costs_match_template::<WAG>(protein_alphabet(), new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<BLOSUM>(protein_alphabet(), new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<HIVB>(protein_alphabet(), new_aa_freqs);
+}

--- a/phylo/src/substitution_models/mod.rs
+++ b/phylo/src/substitution_models/mod.rs
@@ -350,4 +350,4 @@ impl<Q: QMatrix> ParsimonyModel for SubstModel<Q> {
 
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
-pub(crate) mod tests;
+mod tests;

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -7,7 +7,7 @@ use nalgebra::dvector;
 use rand::Rng;
 
 use crate::alignment::{Alignment, Sequences, MSA};
-use crate::alphabets::{Alphabet, AMINOACIDS, GAP};
+use crate::alphabets::{dna_alphabet, protein_alphabet, Alphabet, AMINOACIDS, GAP};
 use crate::evolutionary_models::EvoModel;
 use crate::io::read_sequences;
 use crate::likelihood::ModelSearchCost;
@@ -1230,4 +1230,117 @@ fn dna_zero_diag_scores() {
         &[0.5970915, 0.2940435, 0.00135],
     );
     parsimony_zero_diag_template::<GTR>(&[0.1, 0.3, 0.4, 0.2], &[5.0, 1.0, 1.0, 1.0, 1.0]);
+}
+
+#[cfg(test)]
+fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+    use crate::likelihood::TreeSearchCost;
+
+    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(
+            vec![
+                record!("A", b"CTATATATAC"),
+                record!("B", b"ATATATATAA"),
+                record!("C", b"TTATATATAT"),
+                record!("D", b"TTATATATAT"),
+            ],
+            alphabet,
+        ),
+        &tree,
+    )
+    .unwrap();
+    let info = PhyloInfo { msa, tree };
+
+    let model = SubstModel::<Q>::new(&[], &[]);
+    let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
+    let logl = TreeSearchCost::cost(&c);
+    assert_eq!(logl, TreeSearchCost::cost(&c));
+
+    // The likelihood should be the same if we make the tree dirty without changing it
+    let mut tree = c.info.tree.clone();
+    tree.dirty();
+    c.update_tree(tree);
+    assert_eq!(logl, TreeSearchCost::cost(&c));
+
+    // The likelihood should be the same if we rebuild from scratch
+    let c2 = SCB::new(model, info).build().unwrap();
+    let logl2 = TreeSearchCost::cost(&c2);
+    assert_eq!(logl2, TreeSearchCost::cost(&c2));
+    assert_eq!(logl, logl2);
+}
+
+#[test]
+fn dirty_tree_costs_match() {
+    dirty_tree_costs_match_template::<JC69>(dna_alphabet());
+    dirty_tree_costs_match_template::<K80>(dna_alphabet());
+    dirty_tree_costs_match_template::<HKY>(dna_alphabet());
+    dirty_tree_costs_match_template::<TN93>(dna_alphabet());
+    dirty_tree_costs_match_template::<GTR>(dna_alphabet());
+
+    dirty_tree_costs_match_template::<WAG>(protein_alphabet());
+    dirty_tree_costs_match_template::<HIVB>(protein_alphabet());
+    dirty_tree_costs_match_template::<BLOSUM>(protein_alphabet());
+}
+
+#[cfg(test)]
+fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+    use crate::likelihood::TreeSearchCost;
+
+    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(
+            vec![
+                record!("A", b"CTATATATAC"),
+                record!("B", b"ATATATATAA"),
+                record!("C", b"TTATATATAT"),
+                record!("D", b"TTATATATAT"),
+            ],
+            alphabet,
+        ),
+        &tree,
+    )
+    .unwrap();
+    let info = PhyloInfo {
+        msa: msa.clone(),
+        tree: tree.clone(),
+    };
+
+    let model = SubstModel::<Q>::new(&[], &[]);
+    let mut c = SCB::new(model.clone(), info).build().unwrap();
+    let logl = TreeSearchCost::cost(&c);
+
+    // The likelihood should change if we change branch lengths
+    let mut mutated_tree = tree.clone();
+    mutated_tree.set_blen(&tree.by_id("F").idx, 4.0);
+    mutated_tree.set_blen(&tree.by_id("B").idx, 0.75);
+    c.update_tree(mutated_tree);
+
+    let logl2 = TreeSearchCost::cost(&c);
+    assert_eq!(logl2, TreeSearchCost::cost(&c));
+    assert_ne!(logl, logl2);
+
+    // The likelihood should be the same if we rebuild from scratch with the same modification
+    let new_tree = tree!("(((A:1.0,B:0.75)E:2.0,(C:1.0,D:1.0)F:4.0)G:3.0);");
+    let new_info = PhyloInfo {
+        msa,
+        tree: new_tree,
+    };
+    let c = SCB::new(model, new_info).build().unwrap();
+    let new_logl = TreeSearchCost::cost(&c);
+    assert_eq!(new_logl, TreeSearchCost::cost(&c));
+    assert_eq!(logl2, new_logl);
+}
+
+#[test]
+fn dirty_branch_costs_match() {
+    dirty_branch_costs_match_template::<JC69>(dna_alphabet());
+    dirty_branch_costs_match_template::<K80>(dna_alphabet());
+    dirty_branch_costs_match_template::<HKY>(dna_alphabet());
+    dirty_branch_costs_match_template::<TN93>(dna_alphabet());
+    dirty_branch_costs_match_template::<GTR>(dna_alphabet());
+
+    dirty_branch_costs_match_template::<WAG>(protein_alphabet());
+    dirty_branch_costs_match_template::<HIVB>(protein_alphabet());
+    dirty_branch_costs_match_template::<BLOSUM>(protein_alphabet());
 }

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -1344,3 +1344,109 @@ fn dirty_branch_costs_match() {
     dirty_branch_costs_match_template::<HIVB>(protein_alphabet());
     dirty_branch_costs_match_template::<BLOSUM>(protein_alphabet());
 }
+
+#[cfg(test)]
+fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(
+            vec![
+                record!("A", b"CTATATATAC"),
+                record!("B", b"ATATATATAA"),
+                record!("C", b"TTATATATAT"),
+                record!("D", b"TTATATATAT"),
+            ],
+            alphabet,
+        ),
+        &tree,
+    )
+    .unwrap();
+    let info = PhyloInfo {
+        msa: msa.clone(),
+        tree: tree.clone(),
+    };
+
+    let model = SubstModel::<Q>::new(&[], &[1.0]);
+    let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
+    let logl = c.cost();
+
+    // The likelihood should change if we change model parameters
+    c.set_param(0, 0.5);
+
+    let logl2 = c.cost();
+    assert_eq!(logl2, c.cost());
+    assert_ne!(logl, logl2);
+
+    // The likelihood should be the same if we rebuild from scratch with the same modification
+    let new_model = SubstModel::<Q>::new(&[], &[0.5]);
+    let c = SCB::new(new_model, info).build().unwrap();
+    let new_logl = c.cost();
+    assert_eq!(new_logl, c.cost());
+    assert_eq!(logl2, new_logl);
+}
+
+#[test]
+fn modify_model_params_costs_match() {
+    // does not apply to JC69, WAG, HIVB, BLOSUM which have no params
+    modify_model_params_costs_match_template::<K80>(dna_alphabet());
+    modify_model_params_costs_match_template::<HKY>(dna_alphabet());
+    modify_model_params_costs_match_template::<TN93>(dna_alphabet());
+    modify_model_params_costs_match_template::<GTR>(dna_alphabet());
+}
+
+#[cfg(test)]
+fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
+    alphabet: Alphabet,
+    freqs: FreqVector,
+) {
+    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(
+            vec![
+                record!("A", b"CTATATATAC"),
+                record!("B", b"ATATATATAA"),
+                record!("C", b"TTATATATAT"),
+                record!("D", b"TTATATATAT"),
+            ],
+            alphabet,
+        ),
+        &tree,
+    )
+    .unwrap();
+    let info = PhyloInfo {
+        msa: msa.clone(),
+        tree: tree.clone(),
+    };
+
+    let model = SubstModel::<Q>::new(&[], &[]);
+    let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
+    let logl = c.cost();
+
+    // The likelihood should change if we change model frequencies
+    c.set_freqs(freqs.clone());
+
+    let logl2 = c.cost();
+    assert_eq!(logl2, c.cost());
+    assert_ne!(logl, logl2);
+
+    // The likelihood should be the same if we rebuild from scratch with the same modification
+    let new_model = SubstModel::<Q>::new(freqs.as_slice(), &[]);
+    let c = SCB::new(new_model, info).build().unwrap();
+    let new_logl = c.cost();
+    assert_eq!(new_logl, c.cost());
+    assert_eq!(logl2, new_logl);
+}
+
+#[test]
+fn modify_model_freqs_costs_match() {
+    // does not apply to JC69 and K80 which have no freqs
+    let new_dna_freqs = frequencies!(&[0.1, 0.1, 0.1, 0.7]);
+    modify_model_freqs_costs_match_template::<HKY>(dna_alphabet(), new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<TN93>(dna_alphabet(), new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<GTR>(dna_alphabet(), new_dna_freqs);
+
+    let new_aa_freqs = frequencies!(&[0.05; 20]);
+    modify_model_freqs_costs_match_template::<WAG>(protein_alphabet(), new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<BLOSUM>(protein_alphabet(), new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<HIVB>(protein_alphabet(), new_aa_freqs);
+}

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -1233,9 +1233,7 @@ fn dna_zero_diag_scores() {
 }
 
 #[cfg(test)]
-fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
-    use crate::likelihood::TreeSearchCost;
-
+fn setup_test_info(alphabet: Alphabet) -> PhyloInfo<MSA> {
     let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
     let msa = MSA::from_aligned(
         Sequences::with_alphabet(
@@ -1250,7 +1248,14 @@ fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet
         &tree,
     )
     .unwrap();
-    let info = PhyloInfo { msa, tree };
+    PhyloInfo { msa, tree }
+}
+
+#[cfg(test)]
+fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+    use crate::likelihood::TreeSearchCost;
+
+    let info = setup_test_info(alphabet);
 
     let model = SubstModel::<Q>::new(&[], &[]);
     let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
@@ -1287,33 +1292,16 @@ fn dirty_tree_costs_match() {
 fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
     use crate::likelihood::TreeSearchCost;
 
-    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
-    let msa = MSA::from_aligned(
-        Sequences::with_alphabet(
-            vec![
-                record!("A", b"CTATATATAC"),
-                record!("B", b"ATATATATAA"),
-                record!("C", b"TTATATATAT"),
-                record!("D", b"TTATATATAT"),
-            ],
-            alphabet,
-        ),
-        &tree,
-    )
-    .unwrap();
-    let info = PhyloInfo {
-        msa: msa.clone(),
-        tree: tree.clone(),
-    };
+    let info = setup_test_info(alphabet);
 
     let model = SubstModel::<Q>::new(&[], &[]);
-    let mut c = SCB::new(model.clone(), info).build().unwrap();
+    let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
     let logl = TreeSearchCost::cost(&c);
 
     // The likelihood should change if we change branch lengths
-    let mut mutated_tree = tree.clone();
-    mutated_tree.set_blen(&tree.by_id("F").idx, 4.0);
-    mutated_tree.set_blen(&tree.by_id("B").idx, 0.75);
+    let mut mutated_tree = info.tree.clone();
+    mutated_tree.set_blen(&info.tree.by_id("F").idx, 4.0);
+    mutated_tree.set_blen(&info.tree.by_id("B").idx, 0.75);
     c.update_tree(mutated_tree);
 
     let logl2 = TreeSearchCost::cost(&c);
@@ -1323,7 +1311,7 @@ fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphab
     // The likelihood should be the same if we rebuild from scratch with the same modification
     let new_tree = tree!("(((A:1.0,B:0.75)E:2.0,(C:1.0,D:1.0)F:4.0)G:3.0);");
     let new_info = PhyloInfo {
-        msa,
+        msa: info.msa.clone(),
         tree: new_tree,
     };
     let c = SCB::new(model, new_info).build().unwrap();
@@ -1347,24 +1335,7 @@ fn dirty_branch_costs_match() {
 
 #[cfg(test)]
 fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
-    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
-    let msa = MSA::from_aligned(
-        Sequences::with_alphabet(
-            vec![
-                record!("A", b"CTATATATAC"),
-                record!("B", b"ATATATATAA"),
-                record!("C", b"TTATATATAT"),
-                record!("D", b"TTATATATAT"),
-            ],
-            alphabet,
-        ),
-        &tree,
-    )
-    .unwrap();
-    let info = PhyloInfo {
-        msa: msa.clone(),
-        tree: tree.clone(),
-    };
+    let info = setup_test_info(alphabet);
 
     let model = SubstModel::<Q>::new(&[], &[1.0]);
     let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
@@ -1399,24 +1370,7 @@ fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
     alphabet: Alphabet,
     freqs: FreqVector,
 ) {
-    let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
-    let msa = MSA::from_aligned(
-        Sequences::with_alphabet(
-            vec![
-                record!("A", b"CTATATATAC"),
-                record!("B", b"ATATATATAA"),
-                record!("C", b"TTATATATAT"),
-                record!("D", b"TTATATATAT"),
-            ],
-            alphabet,
-        ),
-        &tree,
-    )
-    .unwrap();
-    let info = PhyloInfo {
-        msa: msa.clone(),
-        tree: tree.clone(),
-    };
+    let info = setup_test_info(alphabet);
 
     let model = SubstModel::<Q>::new(&[], &[]);
     let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();


### PR DESCRIPTION
Added a bunch of tests for `PIPCost` and `SubstitutionCost` to make sure that the costs always match when the tree gets dirty, a branch length changes, or model parameters or frequencies change.