### PR TITLE
Fix/propagate optimisation stop condition to branch length optimiser

### DIFF
--- a/phylo/src/optimisers/topo_optimiser.rs
+++ b/phylo/src/optimisers/topo_optimiser.rs
@@ -149,7 +149,15 @@ where
 
         // Optimise branch lengths on current tree to match PhyML
         if self.c.blen_optimisation() {
-            let o = BranchOptimiser::new(self.c.clone()).run()?;
+            let intermediate_stop_condition = match self.stop_condition {
+                StopCondition::Epsilon(e) => StopCondition::epsilon(e),
+                StopCondition::MaxIterEpsilon(_, e) => StopCondition::epsilon(e),
+                _ => StopCondition::default(),
+            };
+
+            let o =
+                BranchOptimiser::with_stop_condition(self.c.clone(), intermediate_stop_condition)
+                    .run()?;
             if o.final_cost > curr_cost {
                 curr_cost = o.final_cost;
                 let mut tree = o.cost.tree().clone();

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -515,13 +515,12 @@ fn pip_optimise_model_tree() {
     assert!(model_tree_opt_result.final_cost >= model_opt_result.final_cost);
     assert!(model_tree_opt_result.final_cost >= tree_opt_result.initial_cost);
 
-    // These trees used to match at v0.1.0, now rf is 2
-    assert!(
+    assert_eq!(
         model_tree_opt_result
             .cost
             .tree()
-            .robinson_foulds(tree_opt_result.cost.tree())
-            <= 2
+            .robinson_foulds(tree_opt_result.cost.tree()),
+        0
     );
     assert!(model_tree_opt_result.final_cost > tree_opt_result.final_cost);
 


### PR DESCRIPTION
Optimisation stop condition with precision (epsilon) is now properly propagated to branch length optimiser from topology optimiser so that all precisions are the same.