### PR TITLE
Enhancement/refactor randomisers

### DIFF
--- a/phylo/Cargo.toml
+++ b/phylo/Cargo.toml
@@ -64,7 +64,7 @@ ordered-float = "3.7.0"
 pest = "2.7.2"
 pest_derive = "2.7.2"
 rand = { version = "0.9.2" }
-rand_chacha = "0.9.0"
+rand_pcg = "0.9.0"
 rayon = { version = "1.10.0", optional = true }
 rstest = "0.18.1"
 stats-cli = "3.0.1"

--- a/phylo/Cargo.toml
+++ b/phylo/Cargo.toml
@@ -63,7 +63,7 @@ ntimestamp = "1.0.0"
 ordered-float = "3.7.0"
 pest = "2.7.2"
 pest_derive = "2.7.2"
-rand = { version = "0.9.0", features = ["small_rng"] }
+rand = { version = "0.9.3" }
 rand_chacha = "0.9.0"
 rayon = { version = "1.10.0", optional = true }
 rstest = "0.18.1"

--- a/phylo/Cargo.toml
+++ b/phylo/Cargo.toml
@@ -64,6 +64,7 @@ ordered-float = "3.7.0"
 pest = "2.7.2"
 pest_derive = "2.7.2"
 rand = { version = "0.9.0", features = ["small_rng"] }
+rand_chacha = "0.9.0"
 rayon = { version = "1.10.0", optional = true }
 rstest = "0.18.1"
 stats-cli = "3.0.1"

--- a/phylo/Cargo.toml
+++ b/phylo/Cargo.toml
@@ -63,7 +63,7 @@ ntimestamp = "1.0.0"
 ordered-float = "3.7.0"
 pest = "2.7.2"
 pest_derive = "2.7.2"
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { version = "0.9.0", features = ["small_rng"] }
 rayon = { version = "1.10.0", optional = true }
 rstest = "0.18.1"
 stats-cli = "3.0.1"

--- a/phylo/Cargo.toml
+++ b/phylo/Cargo.toml
@@ -63,7 +63,7 @@ ntimestamp = "1.0.0"
 ordered-float = "3.7.0"
 pest = "2.7.2"
 pest_derive = "2.7.2"
-rand = { version = "0.9.3" }
+rand = { version = "0.9.2" }
 rand_chacha = "0.9.0"
 rayon = { version = "1.10.0", optional = true }
 rstest = "0.18.1"

--- a/phylo/benches/helpers.rs
+++ b/phylo/benches/helpers.rs
@@ -39,7 +39,7 @@ pub const AA_MEDIUM_30X86: &str = "data/benchmark-datasets/aa/medium/nagya1_Clus
 
 pub fn black_box_deterministic_phylo_info(seq_file: impl Into<PathBuf>) -> PhyloInfo<MSA> {
     // Only use the FakeGenerator for deterministic benchmarking
-    let mut fake_rng = FakeGenerator::new();
+    let mut fake_rng = FakeGenerator::default();
     black_box(
         PhyloInfoBuilder::new(seq_file.into())
             .build_w_rng(&mut fake_rng)

--- a/phylo/benches/helpers.rs
+++ b/phylo/benches/helpers.rs
@@ -39,10 +39,10 @@ pub const AA_MEDIUM_30X86: &str = "data/benchmark-datasets/aa/medium/nagya1_Clus
 
 pub fn black_box_deterministic_phylo_info(seq_file: impl Into<PathBuf>) -> PhyloInfo<MSA> {
     // Only use the FakeGenerator for deterministic benchmarking
-    let fake_rng = FakeGenerator::new();
+    let mut fake_rng = FakeGenerator::new();
     black_box(
         PhyloInfoBuilder::new(seq_file.into())
-            .build_w_rng(&fake_rng)
+            .build_w_rng(&mut fake_rng)
             .expect("sequence file should be able to build phylo info"),
     )
 }

--- a/phylo/benches/spr.rs
+++ b/phylo/benches/spr.rs
@@ -8,7 +8,7 @@ use phylo::evolutionary_models::FrequencyOptimisation;
 use phylo::likelihood::TreeSearchCost;
 use phylo::optimisers::{Compatible, MoveOptimiser, SprOptimiser, TopologyOptimiser};
 use phylo::pip_model::PIPCost;
-use phylo::random::FakeGenerator;
+use phylo::random::FakeRng;
 use phylo::substitution_models::{QMatrix, QMatrixMaker, JC69, WAG};
 use phylo::tree::NodeIdx;
 
@@ -23,7 +23,7 @@ fn single_spr_cycle<C: TreeSearchCost + Clone + Display + Send + Compatible<SprO
     prune_locations: &[&NodeIdx],
     spr_optimiser: SprOptimiser,
 ) -> anyhow::Result<f64> {
-    TopologyOptimiser::<SprOptimiser, C, FakeGenerator>::fold_improving_moves(
+    TopologyOptimiser::<SprOptimiser, C, FakeRng>::fold_improving_moves(
         &mut cost_fn,
         &spr_optimiser,
         f64::MIN,

--- a/phylo/benches/topo.rs
+++ b/phylo/benches/topo.rs
@@ -21,7 +21,7 @@ fn run_fixed_iter_topo<C: TreeSearchCost + Clone + Display + Send + Compatible<S
     cost: C,
 ) -> anyhow::Result<f64> {
     // Only use the FakeGenerator for deterministic benchmarking
-    let mut fake_rng = FakeGenerator::new();
+    let mut fake_rng = FakeGenerator::default();
     let topo_opt = TopologyOptimiser::with_stop_condition(
         cost,
         SprOptimiser {},

--- a/phylo/benches/topo.rs
+++ b/phylo/benches/topo.rs
@@ -21,11 +21,11 @@ fn run_fixed_iter_topo<C: TreeSearchCost + Clone + Display + Send + Compatible<S
     cost: C,
 ) -> anyhow::Result<f64> {
     // Only use the FakeGenerator for deterministic benchmarking
-    let fake_rng = FakeGenerator::new();
+    let mut fake_rng = FakeGenerator::new();
     let topo_opt = TopologyOptimiser::with_stop_condition(
         cost,
         SprOptimiser {},
-        &fake_rng,
+        &mut fake_rng,
         StopCondition::fixed_iter(NonZero::new(3).unwrap()),
     );
     Ok(topo_opt.run()?.final_cost)

--- a/phylo/benches/tree_from_msa.rs
+++ b/phylo/benches/tree_from_msa.rs
@@ -32,7 +32,7 @@ fn run_optimisation(
     epsilon: f64,
 ) -> Result<(f64, Tree)> {
     // Only use the FakeGenerator for deterministic benchmarking
-    let fake_rng = FakeGenerator::new();
+    let mut fake_rng = FakeGenerator::new();
     let mut cost = cost;
     let mut prev_cost = f64::NEG_INFINITY;
     let mut final_cost = TreeSearchCost::cost(&cost);
@@ -44,7 +44,7 @@ fn run_optimisation(
 
         prev_cost = final_cost;
         let model_optimiser = ModelOptimiser::new(cost, freq_opt);
-        let o = TopologyOptimiser::new(model_optimiser.run()?.cost, SprOptimiser {}, &fake_rng)
+        let o = TopologyOptimiser::new(model_optimiser.run()?.cost, SprOptimiser {}, &mut fake_rng)
             .run()
             .unwrap();
         final_cost = o.final_cost;

--- a/phylo/benches/tree_from_msa.rs
+++ b/phylo/benches/tree_from_msa.rs
@@ -32,7 +32,7 @@ fn run_optimisation(
     epsilon: f64,
 ) -> Result<(f64, Tree)> {
     // Only use the FakeGenerator for deterministic benchmarking
-    let mut fake_rng = FakeGenerator::new();
+    let mut fake_rng = FakeGenerator::default();
     let mut cost = cost;
     let mut prev_cost = f64::NEG_INFINITY;
     let mut final_cost = TreeSearchCost::cost(&cost);

--- a/phylo/examples/rng_examples.rs
+++ b/phylo/examples/rng_examples.rs
@@ -1,4 +1,4 @@
-use rand::distributions::WeightedIndex;
+use rand::distr::weighted::WeightedIndex;
 use rand::rngs::{SmallRng, StdRng};
 use std::iter::repeat_n;
 

--- a/phylo/examples/rng_examples.rs
+++ b/phylo/examples/rng_examples.rs
@@ -6,7 +6,7 @@ fn main() {
     // 1. Using the default RNG (StdRng-based)
     let seed = 42;
     println!("1. RNG (StdRng) with seed {seed} - reproducible:");
-    let rng = DefaultGenerator::new(seed);
+    let mut rng = DefaultGenerator::new(seed);
     for i in 0..3 {
         println!("  {i}: {:.6}", rng.gen::<f64>());
     }
@@ -20,7 +20,7 @@ fn main() {
 
     // 2. Generating from default RNG:
     println!("2. Generating from default RNG:");
-    let rng = DefaultGenerator::default();
+    let mut rng = DefaultGenerator::default();
     println!("  Random f64: {:.6}", rng.gen::<f64>());
     println!("  Random u32: {}", rng.gen::<u32>());
     println!("  Random i32: {}", rng.gen::<i32>());
@@ -34,7 +34,7 @@ fn main() {
     // 3. Creating a custom StdRng instance
     let seed = 123;
     println!("3. Custom StdRng instance with seed {seed} - reproducible:");
-    let custom_std_rng = RandomGenerator::<StdRng>::new(seed);
+    let mut custom_std_rng = RandomGenerator::<StdRng>::new(seed);
     for i in 0..3 {
         println!("  {i}: {:.6}", custom_std_rng.gen::<f64>());
     }
@@ -63,7 +63,7 @@ fn main() {
     // 5. Using a different seed for another StdRng instance
     let seed = 456;
     println!("5. Another StdRng instance with different seed {seed}:");
-    let another_std_rng: RandomGenerator<StdRng> = RandomGenerator::new(seed);
+    let mut another_std_rng: RandomGenerator<StdRng> = RandomGenerator::new(seed);
     for i in 0..3 {
         println!("  {i}: {:.6}", another_std_rng.gen::<f64>());
     }
@@ -71,7 +71,7 @@ fn main() {
 
     // 6. Creating a custom RNG instance with a different generator
     println!("6. Custom RNG instance with SmallRng with seed {seed}:");
-    let secure_rng: RandomGenerator<SmallRng> = RandomGenerator::new(seed);
+    let mut secure_rng: RandomGenerator<SmallRng> = RandomGenerator::new(seed);
     for i in 0..3 {
         println!("  {i}: {:.6}", secure_rng.gen::<f64>());
     }

--- a/phylo/examples/rng_examples.rs
+++ b/phylo/examples/rng_examples.rs
@@ -1,28 +1,16 @@
 use rand::distr::weighted::WeightedIndex;
-use rand::rngs::{SmallRng, StdRng};
+use rand::rngs::StdRng;
 use std::iter::repeat_n;
 
 use phylo::random::{DefaultGenerator, RandomGenerator};
 
 fn main() {
-    // 1. Using the default RNG (StdRng-based)
-    let seed = 42;
-    let mut rng = DefaultGenerator::new(seed);
-    println!("1. RNG (StdRng) with seed {} - reproducible:", rng.seed());
-    for i in 0..3 {
-        println!("  {i}: {:.6}", rng.random::<f64>());
-    }
-    // Reset and show reproducibility
-    rng.reseed(seed);
-    println!("After resetting to seed {}:", rng.seed());
-    for i in 0..3 {
-        println!("  {i}: {:.6}", rng.random::<f64>());
-    }
-    println!();
-
-    // 2. Generating from default RNG:
-    println!("2. Generating from default RNG:");
+    // 1. Generating from default RNG (Pcg32, seeded with the current timestamp):
     let mut rng = DefaultGenerator::default();
+    println!(
+        "1. Generating from default RNG (Pcg32-based), seeded with the current timestamp {}:",
+        rng.seed()
+    );
     println!("  Random f64: {:.6}", rng.random::<f64>());
     println!("  Random u32: {}", rng.random::<u32>());
     println!("  Random i32: {}", rng.random::<i32>());
@@ -34,56 +22,46 @@ fn main() {
     let dist = WeightedIndex::new(repeat_n(1.0, 15)).unwrap();
     let sample = rng.sample(&dist);
     println!("  Sample from a uniform weighted distribution: {}", sample);
-
     println!();
 
-    // 3. Creating a custom StdRng instance
-    let seed = 123;
-    println!("3. Custom StdRng instance with seed {seed} - reproducible:");
-    let mut custom_std_rng = RandomGenerator::<StdRng>::new(seed);
+    // 2. Using the default RNG (Pcg32-based)
+    let seed = 42;
+    let mut rng = DefaultGenerator::new(seed);
+    println!(
+        "2. Default RNG (Pcg32) with seed {} - reproducible:",
+        rng.seed()
+    );
     for i in 0..3 {
-        println!("  {i}: {:.6}", custom_std_rng.random::<f64>());
+        println!("  {i}: {:.6}", rng.random::<f64>());
     }
     // Reset and show reproducibility
-    custom_std_rng.reseed(seed);
-    println!("After resetting to seed {seed}:");
+    rng.reseed(seed);
+    println!("After resetting to seed {}:", rng.seed());
     for i in 0..3 {
-        println!("  {i}: {:.6}", custom_std_rng.random::<f64>());
+        println!("  {i}: {:.6}", rng.random::<f64>());
     }
     println!();
 
-    // 4. Generating from the custom StdRng instance
-    println!("4. Generating from custom RNG:");
-    println!("  Random u32: {}", custom_std_rng.random::<u32>());
-    println!("  Random i32: {}", custom_std_rng.random::<i32>());
-    println!("  Probability [0,1): {:.6}", custom_std_rng.random::<f64>());
-    println!("  Range 1-100: {}", custom_std_rng.random_range(1..=100));
+    // 3. Using a different seed for another Pcg32 instance
+    let seed = 123;
+    let mut another_pcg_rng = DefaultGenerator::new(seed);
     println!(
-        "  Range 0.0-10.0: {:.3}",
-        custom_std_rng.random_range(0.0..10.0)
-    );
-    println!("  Boolean (50%): {}", custom_std_rng.random_bool(0.5));
-    println!("  Boolean (25%): {}", custom_std_rng.random_bool(0.25));
-    println!();
-
-    // 5. Using a different seed for another StdRng instance
-    let seed = 456;
-
-    let mut another_std_rng: RandomGenerator<StdRng> = RandomGenerator::new(seed);
-    println!(
-        "5. Another StdRng instance with different seed {}:",
-        another_std_rng.seed()
+        "3. Another Pcg32 instance with different seed {}:",
+        another_pcg_rng.seed()
     );
     for i in 0..3 {
-        println!("  {i}: {:.6}", another_std_rng.random::<f64>());
+        println!("  {i}: {:.6}", another_pcg_rng.random::<f64>());
     }
     println!();
 
-    // 6. Creating a custom RNG instance with a different generator
-    println!("6. Custom RNG instance with SmallRng with seed {seed}:");
-    let mut secure_rng: RandomGenerator<SmallRng> = RandomGenerator::new(seed);
+    // 4. Creating a custom RNG instance with a different generator (StdRng)
+    let mut custom_rng = RandomGenerator::<StdRng>::new(seed);
+    println!(
+        "4. Custom RNG instance with StdRng with seed {}:",
+        custom_rng.seed()
+    );
     for i in 0..3 {
-        println!("  {i}: {:.6}", secure_rng.random::<f64>());
+        println!("  {i}: {:.6}", custom_rng.random::<f64>());
     }
     println!();
 }

--- a/phylo/examples/rng_examples.rs
+++ b/phylo/examples/rng_examples.rs
@@ -1,18 +1,20 @@
+use rand::distributions::WeightedIndex;
 use rand::rngs::{SmallRng, StdRng};
+use std::iter::repeat_n;
 
-use phylo::random::{DefaultGenerator, RandomGenerator, RandomSource};
+use phylo::random::{DefaultGenerator, RandomGenerator};
 
 fn main() {
     // 1. Using the default RNG (StdRng-based)
     let seed = 42;
-    println!("1. RNG (StdRng) with seed {seed} - reproducible:");
     let mut rng = DefaultGenerator::new(seed);
+    println!("1. RNG (StdRng) with seed {} - reproducible:", rng.seed());
     for i in 0..3 {
         println!("  {i}: {:.6}", rng.gen::<f64>());
     }
     // Reset and show reproducibility
     rng.reseed(seed);
-    println!("After resetting to seed {seed}:");
+    println!("After resetting to seed {}:", rng.seed());
     for i in 0..3 {
         println!("  {i}: {:.6}", rng.gen::<f64>());
     }
@@ -29,6 +31,10 @@ fn main() {
     println!("  Range 0.0-10.0: {:.3}", rng.gen_range(0.0..10.0));
     println!("  Boolean (50%): {}", rng.gen_bool(0.5));
     println!("  Boolean (25%): {}", rng.gen_bool(0.25));
+    let dist = WeightedIndex::new(repeat_n(1.0, 15)).unwrap();
+    let sample = rng.sample(&dist);
+    println!("  Sample from a uniform weighted distribution: {}", sample);
+
     println!();
 
     // 3. Creating a custom StdRng instance
@@ -62,8 +68,12 @@ fn main() {
 
     // 5. Using a different seed for another StdRng instance
     let seed = 456;
-    println!("5. Another StdRng instance with different seed {seed}:");
+
     let mut another_std_rng: RandomGenerator<StdRng> = RandomGenerator::new(seed);
+    println!(
+        "5. Another StdRng instance with different seed {}:",
+        another_std_rng.seed()
+    );
     for i in 0..3 {
         println!("  {i}: {:.6}", another_std_rng.gen::<f64>());
     }

--- a/phylo/examples/rng_examples.rs
+++ b/phylo/examples/rng_examples.rs
@@ -10,27 +10,27 @@ fn main() {
     let mut rng = DefaultGenerator::new(seed);
     println!("1. RNG (StdRng) with seed {} - reproducible:", rng.seed());
     for i in 0..3 {
-        println!("  {i}: {:.6}", rng.gen::<f64>());
+        println!("  {i}: {:.6}", rng.random::<f64>());
     }
     // Reset and show reproducibility
     rng.reseed(seed);
     println!("After resetting to seed {}:", rng.seed());
     for i in 0..3 {
-        println!("  {i}: {:.6}", rng.gen::<f64>());
+        println!("  {i}: {:.6}", rng.random::<f64>());
     }
     println!();
 
     // 2. Generating from default RNG:
     println!("2. Generating from default RNG:");
     let mut rng = DefaultGenerator::default();
-    println!("  Random f64: {:.6}", rng.gen::<f64>());
-    println!("  Random u32: {}", rng.gen::<u32>());
-    println!("  Random i32: {}", rng.gen::<i32>());
-    println!("  Probability [0,1): {:.6}", rng.gen::<f64>());
-    println!("  Range 1-100: {}", rng.gen_range(1..=100));
-    println!("  Range 0.0-10.0: {:.3}", rng.gen_range(0.0..10.0));
-    println!("  Boolean (50%): {}", rng.gen_bool(0.5));
-    println!("  Boolean (25%): {}", rng.gen_bool(0.25));
+    println!("  Random f64: {:.6}", rng.random::<f64>());
+    println!("  Random u32: {}", rng.random::<u32>());
+    println!("  Random i32: {}", rng.random::<i32>());
+    println!("  Probability [0,1): {:.6}", rng.random::<f64>());
+    println!("  Range 1-100: {}", rng.random_range(1..=100));
+    println!("  Range 0.0-10.0: {:.3}", rng.random_range(0.0..10.0));
+    println!("  Boolean (50%): {}", rng.random_bool(0.5));
+    println!("  Boolean (25%): {}", rng.random_bool(0.25));
     let dist = WeightedIndex::new(repeat_n(1.0, 15)).unwrap();
     let sample = rng.sample(&dist);
     println!("  Sample from a uniform weighted distribution: {}", sample);
@@ -42,28 +42,28 @@ fn main() {
     println!("3. Custom StdRng instance with seed {seed} - reproducible:");
     let mut custom_std_rng = RandomGenerator::<StdRng>::new(seed);
     for i in 0..3 {
-        println!("  {i}: {:.6}", custom_std_rng.gen::<f64>());
+        println!("  {i}: {:.6}", custom_std_rng.random::<f64>());
     }
     // Reset and show reproducibility
     custom_std_rng.reseed(seed);
     println!("After resetting to seed {seed}:");
     for i in 0..3 {
-        println!("  {i}: {:.6}", custom_std_rng.gen::<f64>());
+        println!("  {i}: {:.6}", custom_std_rng.random::<f64>());
     }
     println!();
 
     // 4. Generating from the custom StdRng instance
     println!("4. Generating from custom RNG:");
-    println!("  Random u32: {}", custom_std_rng.gen::<u32>());
-    println!("  Random i32: {}", custom_std_rng.gen::<i32>());
-    println!("  Probability [0,1): {:.6}", custom_std_rng.gen::<f64>());
-    println!("  Range 1-100: {}", custom_std_rng.gen_range(1..=100));
+    println!("  Random u32: {}", custom_std_rng.random::<u32>());
+    println!("  Random i32: {}", custom_std_rng.random::<i32>());
+    println!("  Probability [0,1): {:.6}", custom_std_rng.random::<f64>());
+    println!("  Range 1-100: {}", custom_std_rng.random_range(1..=100));
     println!(
         "  Range 0.0-10.0: {:.3}",
-        custom_std_rng.gen_range(0.0..10.0)
+        custom_std_rng.random_range(0.0..10.0)
     );
-    println!("  Boolean (50%): {}", custom_std_rng.gen_bool(0.5));
-    println!("  Boolean (25%): {}", custom_std_rng.gen_bool(0.25));
+    println!("  Boolean (50%): {}", custom_std_rng.random_bool(0.5));
+    println!("  Boolean (25%): {}", custom_std_rng.random_bool(0.25));
     println!();
 
     // 5. Using a different seed for another StdRng instance
@@ -75,7 +75,7 @@ fn main() {
         another_std_rng.seed()
     );
     for i in 0..3 {
-        println!("  {i}: {:.6}", another_std_rng.gen::<f64>());
+        println!("  {i}: {:.6}", another_std_rng.random::<f64>());
     }
     println!();
 
@@ -83,7 +83,7 @@ fn main() {
     println!("6. Custom RNG instance with SmallRng with seed {seed}:");
     let mut secure_rng: RandomGenerator<SmallRng> = RandomGenerator::new(seed);
     for i in 0..3 {
-        println!("  {i}: {:.6}", secure_rng.gen::<f64>());
+        println!("  {i}: {:.6}", secure_rng.random::<f64>());
     }
     println!();
 }

--- a/phylo/src/alignment/tests.rs
+++ b/phylo/src/alignment/tests.rs
@@ -1,5 +1,5 @@
+use rand::rng;
 use rand::seq::IteratorRandom;
-use rand::thread_rng;
 
 use crate::alignment::{
     Alignment, AncestralAlignment, InternalAlignments, PairwiseAlignment as PA, SeqMaps, Sequences,
@@ -204,7 +204,7 @@ fn compile_msa_root() {
     let aligned_seqs = test_alignment(
         &["A0", "B1", "C2", "D3", "E4"]
             .into_iter()
-            .choose_multiple(&mut thread_rng(), 5),
+            .choose_multiple(&mut rng(), 5),
     );
     let msa = MSA::from_aligned(aligned_seqs.clone(), &tree).unwrap();
     assert_eq!(

--- a/phylo/src/optimisers/topo_optimiser.rs
+++ b/phylo/src/optimisers/topo_optimiser.rs
@@ -40,7 +40,7 @@ where
     pub(crate) stop_condition: StopCondition,
     pub(crate) move_opti: MO,
     pub(crate) c: C,
-    pub(crate) rng: &'a R,
+    pub(crate) rng: &'a mut R,
 }
 
 impl<'a, MO, C, R> TopologyOptimiser<'a, MO, C, R>
@@ -49,7 +49,7 @@ where
     C: TreeSearchCost + Display + Clone + Send + Compatible<MO>,
     R: RandomSource,
 {
-    pub fn new(cost: C, move_opti: MO, rng: &'a R) -> Self {
+    pub fn new(cost: C, move_opti: MO, rng: &'a mut R) -> Self {
         Self {
             move_opti,
             c: cost,
@@ -58,7 +58,12 @@ where
         }
     }
 
-    pub fn with_stop_condition(cost: C, move_opti: MO, rng: &'a R, stop: StopCondition) -> Self {
+    pub fn with_stop_condition(
+        cost: C,
+        move_opti: MO,
+        rng: &'a mut R,
+        stop: StopCondition,
+    ) -> Self {
         Self {
             c: cost,
             move_opti,
@@ -255,12 +260,12 @@ mod private_tests {
     ) where
         PIPCost<Q, MSA>: Compatible<MO>,
     {
-        let rng = FakeGenerator::new();
+        let mut rng = FakeGenerator::new();
         let model = PIPModel::<Q>::new(&[], &[]);
         let c = PIPCB::new(model.clone(), info.clone()).build().unwrap();
         let init_cost = c.cost();
 
-        let mut optimiser = TopologyOptimiser::new(c.clone(), move_optimiser, &rng);
+        let mut optimiser = TopologyOptimiser::new(c.clone(), move_optimiser, &mut rng);
         let optimised_cost = optimiser.single_optimisation_iteration().unwrap();
 
         assert!(optimised_cost > init_cost);
@@ -336,12 +341,12 @@ mod private_tests {
     ) where
         SubstitutionCost<Q, MSA>: Compatible<MO>,
     {
-        let rng = FakeGenerator::new();
+        let mut rng = FakeGenerator::new();
         let model = SubstModel::<Q>::new(&[], &[]);
         let c = SCB::new(model.clone(), info.clone()).build().unwrap();
         let init_cost = c.cost();
 
-        let mut optimiser = TopologyOptimiser::new(c.clone(), move_optimiser, &rng);
+        let mut optimiser = TopologyOptimiser::new(c.clone(), move_optimiser, &mut rng);
         let optimised_cost = optimiser.single_optimisation_iteration().unwrap();
 
         assert!(optimised_cost > init_cost);

--- a/phylo/src/optimisers/topo_optimiser.rs
+++ b/phylo/src/optimisers/topo_optimiser.rs
@@ -36,7 +36,7 @@ pub struct TopologyOptimiser<'a, MO, C, R>
 where
     MO: MoveOptimiser,
     C: TreeSearchCost + Display + Clone + Send + Compatible<MO>,
-    R: Rng + SeedableRng + Send,
+    R: Rng + SeedableRng,
 {
     pub(crate) stop_condition: StopCondition,
     pub(crate) move_opti: MO,
@@ -48,7 +48,7 @@ impl<'a, MO, C, R> TopologyOptimiser<'a, MO, C, R>
 where
     MO: MoveOptimiser,
     C: TreeSearchCost + Display + Clone + Send + Compatible<MO>,
-    R: Rng + SeedableRng + Send,
+    R: Rng + SeedableRng,
 {
     pub fn new(cost: C, move_opti: MO, rng: &'a mut RandomGenerator<R>) -> Self {
         Self {

--- a/phylo/src/optimisers/topo_optimiser.rs
+++ b/phylo/src/optimisers/topo_optimiser.rs
@@ -261,7 +261,7 @@ mod private_tests {
     ) where
         PIPCost<Q, MSA>: Compatible<MO>,
     {
-        let mut rng = FakeGenerator::new();
+        let mut rng = FakeGenerator::default();
         let model = PIPModel::<Q>::new(&[], &[]);
         let c = PIPCB::new(model.clone(), info.clone()).build().unwrap();
         let init_cost = c.cost();
@@ -342,7 +342,7 @@ mod private_tests {
     ) where
         SubstitutionCost<Q, MSA>: Compatible<MO>,
     {
-        let mut rng = FakeGenerator::new();
+        let mut rng = FakeGenerator::default();
         let model = SubstModel::<Q>::new(&[], &[]);
         let c = SCB::new(model.clone(), info.clone()).build().unwrap();
         let init_cost = c.cost();

--- a/phylo/src/optimisers/topo_optimiser.rs
+++ b/phylo/src/optimisers/topo_optimiser.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use itertools::Itertools;
 use log::{debug, info};
+use rand::{Rng, SeedableRng};
 
 use crate::alignment::Alignment;
 use crate::likelihood::TreeSearchCost;
@@ -12,7 +13,7 @@ use crate::optimisers::{
 use crate::parsimony::scoring::ParsimonyScoring;
 use crate::parsimony::{BasicParsimonyCost, DolloParsimonyCost};
 use crate::pip_model::PIPCost;
-use crate::random::RandomSource;
+use crate::random::RandomGenerator;
 use crate::substitution_models::{QMatrix, SubstitutionCost};
 use crate::tree::NodeIdx;
 use crate::Result;
@@ -35,21 +36,21 @@ pub struct TopologyOptimiser<'a, MO, C, R>
 where
     MO: MoveOptimiser,
     C: TreeSearchCost + Display + Clone + Send + Compatible<MO>,
-    R: RandomSource,
+    R: Rng + SeedableRng + Send,
 {
     pub(crate) stop_condition: StopCondition,
     pub(crate) move_opti: MO,
     pub(crate) c: C,
-    pub(crate) rng: &'a mut R,
+    pub(crate) rng: &'a mut RandomGenerator<R>,
 }
 
 impl<'a, MO, C, R> TopologyOptimiser<'a, MO, C, R>
 where
     MO: MoveOptimiser,
     C: TreeSearchCost + Display + Clone + Send + Compatible<MO>,
-    R: RandomSource,
+    R: Rng + SeedableRng + Send,
 {
-    pub fn new(cost: C, move_opti: MO, rng: &'a mut R) -> Self {
+    pub fn new(cost: C, move_opti: MO, rng: &'a mut RandomGenerator<R>) -> Self {
         Self {
             move_opti,
             c: cost,
@@ -61,7 +62,7 @@ where
     pub fn with_stop_condition(
         cost: C,
         move_opti: MO,
-        rng: &'a mut R,
+        rng: &'a mut RandomGenerator<R>,
         stop: StopCondition,
     ) -> Self {
         Self {
@@ -97,7 +98,7 @@ where
     /// let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     /// let c = SubstitutionCostBuilder::new(k80, info).build()?;
     /// let unopt_cost = c.cost();
-    /// let result = TopologyOptimiser::new(c, SprOptimiser {}, &DefaultGenerator::default()).run()?;
+    /// let result = TopologyOptimiser::new(c, SprOptimiser {}, &mut DefaultGenerator::default()).run()?;
     /// assert_eq!(unopt_cost, result.initial_cost);
     /// assert!(result.final_cost > result.initial_cost);
     /// assert!(result.iterations <= 100);

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -228,6 +228,7 @@ fn k80_sim_data_vs_phyml() {
 
     let tree = o.cost.tree();
     assert_eq!(tree.robinson_foulds(&phyml_info.tree), 0);
+    assert_relative_eq!(tree.length, phyml_info.tree.length, epsilon = 1e-4);
 
     let taxa = ["Gorilla", "Orangutan", "Gibbon", "Human", "Chimpanzee"];
     for taxon in taxa.iter() {
@@ -237,8 +238,6 @@ fn k80_sim_data_vs_phyml() {
             epsilon = 1e-5
         );
     }
-    assert_relative_eq!(tree.length, phyml_info.tree.length, epsilon = 1e-4);
-    assert_eq!(tree.robinson_foulds(&phyml_info.tree), 0);
 }
 
 #[test]
@@ -273,7 +272,10 @@ fn k80_sim_data_vs_phyml_wrong_start() {
     assert_relative_eq!(o.final_cost, -4038.721121221992, epsilon = 1e-5);
 
     let tree = o.cost.tree();
-    let taxa = ["Gorilla", "Orangutan", "Gibbon", "Human", "Chimpanzee"];
+    assert_relative_eq!(tree.length, phyml_info.tree.length, epsilon = 1e-4);
+    assert_eq!(tree.robinson_foulds(&phyml_info.tree), 0);
+
+    let taxa = ["Gorilla", "Orangutan", "Gibbon", "Chimpanzee"];
     for taxon in taxa.iter() {
         assert_relative_eq!(
             tree.by_id(taxon).blen,
@@ -281,8 +283,12 @@ fn k80_sim_data_vs_phyml_wrong_start() {
             epsilon = 1e-5
         );
     }
-    assert_relative_eq!(tree.length, phyml_info.tree.length, epsilon = 1e-4);
-    assert_eq!(tree.robinson_foulds(&phyml_info.tree), 0);
+    let human_idx = tree.idx("Human");
+    assert_relative_eq!(
+        tree.by_id("Human").blen + tree.node(&tree.sibling(&human_idx).unwrap()).blen,
+        phyml_info.tree.by_id("Human").blen,
+        epsilon = 1e-4
+    );
 }
 
 #[test]

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -33,7 +33,7 @@ macro_rules! define_optimise_trees {
                 let mut fake_rng = FakeGenerator::default();
                 let start_info = PIB::new(seq_file).build_w_rng(&mut fake_rng).unwrap();
                 let cost = $builder::new(model, start_info).build().unwrap();
-                TopologyOptimiser::new(cost, $move_optimiser {}, &fake_rng).run().unwrap()
+                TopologyOptimiser::new(cost, $move_optimiser {}, &mut fake_rng).run().unwrap()
             }
 
             #[cfg(feature = "precomputed-test-results")]
@@ -98,7 +98,7 @@ fn k80_simple() {
     let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(k80.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
-    let o = TopologyOptimiser::new(c, SprOptimiser {}, &FakeGenerator::default())
+    let o = TopologyOptimiser::new(c, SprOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
 
@@ -130,7 +130,7 @@ fn k80_simple_nni() {
     let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(k80.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
-    let o = TopologyOptimiser::new(c, NniOptimiser {}, &FakeGenerator::default())
+    let o = TopologyOptimiser::new(c, NniOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
 
@@ -153,7 +153,7 @@ fn k80_sim_data_from_given() {
     let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(k80.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
-    let o = TopologyOptimiser::new(c, SprOptimiser {}, &FakeGenerator::default())
+    let o = TopologyOptimiser::new(c, SprOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
 
@@ -170,15 +170,15 @@ fn k80_sim_data_from_given() {
 #[test]
 fn k80_sim_data_from_nj() {
     // Check that optimisation on k80 data improves k80 likelihood when starting from an NJ tree
-    let fake_rng = FakeGenerator::default();
+    let mut fake_rng = FakeGenerator::default();
     let fldr = Path::new("./data/sim/K80");
     let info = PIB::new(fldr.join("K80.fasta"))
-        .build_w_rng(&fake_rng)
+        .build_w_rng(&mut fake_rng)
         .unwrap();
     let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
     let c = SCB::new(k80.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
-    let o = TopologyOptimiser::new(c, SprOptimiser {}, &fake_rng)
+    let o = TopologyOptimiser::new(c, SprOptimiser {}, &mut fake_rng)
         .run()
         .unwrap();
 
@@ -198,12 +198,12 @@ fn k80_sim_data_vs_phyml() {
     // Check that optimisation on k80 data under JC69 produces similar tree to PhyML with matching likelihood
     let fldr = Path::new("./data/sim/");
     let info = PIB::with_attrs(fldr.join("K80/K80.fasta"), fldr.join("tree.newick"))
-        .build_w_rng(&FakeGenerator::default())
+        .build_w_rng(&mut FakeGenerator::default())
         .unwrap();
     let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let c = SCB::new(jc69.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
-    let o = TopologyOptimiser::new(c, SprOptimiser {}, &FakeGenerator::default())
+    let o = TopologyOptimiser::new(c, SprOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
 
@@ -253,7 +253,7 @@ fn k80_sim_data_vs_phyml_wrong_start() {
     let jc69 = SubstModel::<JC69>::new(&[], &[]);
     let c = SCB::new(jc69.clone(), info).build().unwrap();
     let unopt_logl = c.cost();
-    let o = TopologyOptimiser::new(c, SprOptimiser {}, &FakeGenerator::default())
+    let o = TopologyOptimiser::new(c, SprOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
 
@@ -373,7 +373,7 @@ fn pip_vs_subst_dna_tree() {
     let k80_res = TopologyOptimiser::new(
         SCB::new(k80.clone(), info.clone()).build().unwrap(),
         SprOptimiser {},
-        &FakeGenerator::default(),
+        &mut FakeGenerator::default(),
     )
     .run()
     .unwrap();
@@ -382,7 +382,7 @@ fn pip_vs_subst_dna_tree() {
     let pip_res = TopologyOptimiser::new(
         PIPCB::new(pip.clone(), info).build().unwrap(),
         SprOptimiser {},
-        &FakeGenerator::default(),
+        &mut FakeGenerator::default(),
     )
     .run()
     .unwrap();
@@ -481,7 +481,7 @@ fn pip_optimise_model_tree() {
     let fldr = Path::new("./data/phyml_protein_example/");
     let seq_file = fldr.join("seqs.fasta");
     let start_info = PIB::new(seq_file.clone())
-        .build_w_rng(&FakeGenerator::default())
+        .build_w_rng(&mut FakeGenerator::default())
         .unwrap();
 
     // Optimise tree starting from an NJ tree and initial model
@@ -549,7 +549,7 @@ fn wag_vs_phyml_empirical_freqs() {
     let seq_file = fldr.join("seqs.fasta");
     let tree_file = fldr.join("jati_wag_empirical.newick");
     let start_info = PIB::new(seq_file.clone())
-        .build_w_rng(&FakeGenerator::default())
+        .build_w_rng(&mut FakeGenerator::default())
         .unwrap();
 
     let wag = SubstModel::<WAG>::new(&[], &[]);
@@ -587,7 +587,7 @@ fn pip_wag_vs_phyml_empirical_freqs() {
     let tree_file = fldr.join("jati_pip_wag_empirical.newick");
 
     let start_info = PIB::new(seq_file.clone())
-        .build_w_rng(&FakeGenerator::default())
+        .build_w_rng(&mut FakeGenerator::default())
         .unwrap();
     let pip = PIPModel::<WAG>::new(&[], &[1.0, 2.0]);
     // Use empirical frequencies and optimise lambda and mu for PIP
@@ -667,7 +667,7 @@ fn basic_parsimony_tree_search() {
     let cost = BasicParsimonyCost::new(info).unwrap();
     assert_eq!(cost.cost(), -6.0);
 
-    let res = TopologyOptimiser::new(cost, SprOptimiser {}, &FakeGenerator::default())
+    let res = TopologyOptimiser::new(cost, SprOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
     assert_eq!(res.final_cost, -4.0);
@@ -695,7 +695,7 @@ fn dollo_tree_search() {
 
     let c = DolloParsimonyCost::with_scoring(info, scoring);
     let unopt_score = c.cost();
-    let o = TopologyOptimiser::new(c, SprOptimiser {}, &FakeGenerator::default())
+    let o = TopologyOptimiser::new(c, SprOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
 
@@ -713,7 +713,7 @@ fn dollo_tree_search_sim_data_simple() {
     let c = DolloParsimonyCost::new(info);
     let unopt_score = c.cost();
 
-    let o = TopologyOptimiser::new(c, SprOptimiser {}, &FakeGenerator::default())
+    let o = TopologyOptimiser::new(c, SprOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
     assert!(o.final_cost >= unopt_score);
@@ -737,7 +737,7 @@ fn dollo_tree_search_sim_data_model() {
 
     let c = DolloParsimonyCost::with_scoring(info, scoring);
     let unopt_score = c.cost();
-    let o = TopologyOptimiser::new(c, SprOptimiser {}, &FakeGenerator::default())
+    let o = TopologyOptimiser::new(c, SprOptimiser {}, &mut FakeGenerator::default())
         .run()
         .unwrap();
 
@@ -750,14 +750,14 @@ fn dollo_tree_search_sim_data_model() {
 fn fix_iter_low() {
     let fldr = Path::new("./data/phyml_protein_example/");
     let seq_file = fldr.join("seqs.fasta");
-    let rng = FakeGenerator::default();
+    let mut rng = FakeGenerator::default();
 
     let wag = SubstModel::<WAG>::new(&[], &[]);
-    let info = PIB::new(seq_file).build_w_rng(&rng).unwrap();
+    let info = PIB::new(seq_file).build_w_rng(&mut rng).unwrap();
     let c = SCB::new(wag, info).build().unwrap();
     let unopt_cost = c.cost();
 
-    let res_default = TopologyOptimiser::new(c.clone(), SprOptimiser {}, &rng)
+    let res_default = TopologyOptimiser::new(c.clone(), SprOptimiser {}, &mut rng)
         .run()
         .unwrap();
     // Without the stop condition and with the fake rng will run deterministically for 4 iterations
@@ -767,7 +767,7 @@ fn fix_iter_low() {
     let result = TopologyOptimiser::with_stop_condition(
         c,
         SprOptimiser {},
-        &rng,
+        &mut rng,
         StopCondition::fixed_iter(NonZeroUsize::new(1).unwrap()),
     )
     .run()
@@ -783,15 +783,15 @@ fn fix_iter_low() {
 fn precision() {
     let fldr = Path::new("./data/phyml_protein_example/");
     let seq_file = fldr.join("seqs.fasta");
-    let rng = FakeGenerator::default();
+    let mut rng = FakeGenerator::default();
     let epsilon = 1e-1;
 
     let wag = SubstModel::<WAG>::new(&[], &[]);
-    let info = PIB::new(seq_file).build_w_rng(&rng).unwrap();
+    let info = PIB::new(seq_file).build_w_rng(&mut rng).unwrap();
     let c = SCB::new(wag, info).build().unwrap();
     let unopt_cost = c.cost();
 
-    let res_default = TopologyOptimiser::new(c.clone(), SprOptimiser {}, &rng)
+    let res_default = TopologyOptimiser::new(c.clone(), SprOptimiser {}, &mut rng)
         .run()
         .unwrap();
     // Without the stop condition and with the fake rng will run deterministically for 4 iterations
@@ -801,7 +801,7 @@ fn precision() {
     let result = TopologyOptimiser::with_stop_condition(
         c,
         SprOptimiser {},
-        &rng,
+        &mut rng,
         StopCondition::epsilon(epsilon),
     )
     .run()
@@ -819,14 +819,14 @@ fn precision() {
 fn fix_iter() {
     let fldr = Path::new("./data/phyml_protein_example/");
     let seq_file = fldr.join("nogap_seqs.fasta");
-    let rng = FakeGenerator::default();
+    let mut rng = FakeGenerator::default();
 
     let wag = SubstModel::<WAG>::new(&[], &[]);
-    let info = PIB::new(seq_file).build_w_rng(&rng).unwrap();
+    let info = PIB::new(seq_file).build_w_rng(&mut rng).unwrap();
     let c = SCB::new(wag, info).build().unwrap();
     let unopt_cost = c.cost();
 
-    let res_default = TopologyOptimiser::new(c.clone(), SprOptimiser {}, &rng)
+    let res_default = TopologyOptimiser::new(c.clone(), SprOptimiser {}, &mut rng)
         .run()
         .unwrap();
     // Without the stop condition and with the fake rng will run deterministically for 2 iterations
@@ -836,7 +836,7 @@ fn fix_iter() {
     let result = TopologyOptimiser::with_stop_condition(
         c,
         SprOptimiser {},
-        &rng,
+        &mut rng,
         StopCondition::fixed_iter(NonZeroUsize::new(6).unwrap()),
     )
     .run()
@@ -851,17 +851,19 @@ fn fix_iter() {
 fn max_iter() {
     let fldr = Path::new("./data/phyml_protein_example/");
     let seq_file = fldr.join("nogap_seqs.fasta");
-    let rng = FakeGenerator::default();
     let epsilon = 1e-10;
 
     let wag = SubstModel::<WAG>::new(&[], &[]);
-    let info = PIB::new(seq_file).build_w_rng(&rng).unwrap();
+    let info = PIB::new(seq_file)
+        .build_w_rng(&mut FakeGenerator::default())
+        .unwrap();
     let c = SCB::new(wag, info).build().unwrap();
     let unopt_cost = c.cost();
 
-    let res_default = TopologyOptimiser::new(c.clone(), SprOptimiser {}, &rng)
-        .run()
-        .unwrap();
+    let res_default =
+        TopologyOptimiser::new(c.clone(), SprOptimiser {}, &mut FakeGenerator::default())
+            .run()
+            .unwrap();
     // Without the stop condition and with the fake rng will run deterministically for 2 iterations
     assert_eq!(res_default.iterations, 2);
 
@@ -869,7 +871,7 @@ fn max_iter() {
     let result = TopologyOptimiser::with_stop_condition(
         c,
         SprOptimiser {},
-        &rng,
+        &mut FakeGenerator::default(),
         StopCondition::max_iter_epsilon(NonZeroUsize::new(3).unwrap(), epsilon),
     )
     .run()
@@ -895,8 +897,8 @@ fn example_main_from_readme() {
         let k80 = SubstModel::<K80>::new(&[], &[4.0, 1.0]);
         let c = SubstitutionCostBuilder::new(k80, info).build()?;
         let unopt_cost = c.cost();
-        let rng = FakeGenerator::default();
-        let optimiser = TopologyOptimiser::new(c, SprOptimiser {}, &rng);
+        let mut rng = FakeGenerator::default();
+        let optimiser = TopologyOptimiser::new(c, SprOptimiser {}, &mut rng);
         let result = optimiser.run()?;
         assert_eq!(unopt_cost, result.initial_cost);
         assert!(result.final_cost > result.initial_cost);

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -60,7 +60,7 @@ macro_rules! define_optimise_trees {
                     }
                 } else {
                     let cost = $builder::new(model.clone(), start_info).build().unwrap();
-                    let res = TopologyOptimiser::new(cost, $move_optimiser {}, &fake_rng).run().unwrap();
+                    let res = TopologyOptimiser::new(cost, $move_optimiser {}, &mut fake_rng).run().unwrap();
                     assert!(crate::io::write_newick_to_file(
                         &[res.cost.tree().clone()],
                         tree_file

--- a/phylo/src/parsimony/helpers.rs
+++ b/phylo/src/parsimony/helpers.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Debug};
 
-use rand::random;
+use rand::{rng, Rng};
 
 use crate::alphabets::ParsimonySet;
 
@@ -113,5 +113,5 @@ impl ParsimonySite {
 }
 
 pub(crate) fn rng_len(l: usize) -> usize {
-    random::<usize>() % l
+    (rng().random_range(0..(l as u64))) as usize
 }

--- a/phylo/src/parsimony/helpers.rs
+++ b/phylo/src/parsimony/helpers.rs
@@ -113,5 +113,5 @@ impl ParsimonySite {
 }
 
 pub(crate) fn rng_len(l: usize) -> usize {
-    (rng().random_range(0..(l as u64))) as usize
+    rng().random_range(0..l)
 }

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Ok};
 use log::{info, warn};
+use rand::{Rng, SeedableRng};
 
 use crate::alignment::{Aligner, Alignment, AncestralAlignment, Sequences, MASA, MSA};
 use crate::alphabets::Alphabet;
@@ -11,7 +12,7 @@ use crate::io::{self, DataError};
 use crate::parsimony::ParsimonyAligner;
 use crate::parsimony_presence_absence::ParsimonyPresenceAbsence;
 use crate::phylo_info::PhyloInfo;
-use crate::random::{DefaultGenerator, RandomSource};
+use crate::random::{DefaultGenerator, RandomGenerator};
 use crate::tree::{build_nj_tree_w_rng, Tree};
 use crate::Result;
 
@@ -137,7 +138,10 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
     /// assert_eq!(info.tree.len(), 7);
     /// # Ok(()) }
     /// ```
-    pub fn build_w_rng(self, rng: &mut impl RandomSource) -> Result<PhyloInfo<A>> {
+    pub fn build_w_rng<R>(self, rng: &mut RandomGenerator<R>) -> Result<PhyloInfo<A>>
+    where
+        R: Rng + SeedableRng + Send,
+    {
         let sequences = self.read_sequences()?;
         let tree = match &self.tree_file {
             Some(tree_file) => self.read_tree(tree_file)?,
@@ -162,7 +166,13 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
         self.build_with_ancestors_w_rng(&mut DefaultGenerator::default())
     }
 
-    pub fn build_with_ancestors_w_rng(self, rng: &mut impl RandomSource) -> Result<PhyloInfo<AA>> {
+    pub fn build_with_ancestors_w_rng<R>(
+        self,
+        rng: &mut RandomGenerator<R>,
+    ) -> Result<PhyloInfo<AA>>
+    where
+        R: Rng + SeedableRng + Send,
+    {
         let sequences = self.read_sequences()?;
         let mut tree = match &self.tree_file {
             Some(tree_file) => self.read_tree(tree_file)?,

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -111,7 +111,7 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
     }
 
     pub fn build(self) -> Result<PhyloInfo<A>> {
-        self.build_w_rng(&DefaultGenerator::default())
+        self.build_w_rng(&mut DefaultGenerator::default())
     }
 
     /// Builds the PhyloInfo struct from the sequence file and the tree file (if provided).
@@ -137,7 +137,7 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
     /// assert_eq!(info.tree.len(), 7);
     /// # Ok(()) }
     /// ```
-    pub fn build_w_rng(self, rng: &impl RandomSource) -> Result<PhyloInfo<A>> {
+    pub fn build_w_rng(self, rng: &mut impl RandomSource) -> Result<PhyloInfo<A>> {
         let sequences = self.read_sequences()?;
         let tree = match &self.tree_file {
             Some(tree_file) => self.read_tree(tree_file)?,
@@ -159,10 +159,10 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
     }
 
     pub fn build_with_ancestors(self) -> Result<PhyloInfo<AA>> {
-        self.build_with_ancestors_w_rng(&DefaultGenerator::default())
+        self.build_with_ancestors_w_rng(&mut DefaultGenerator::default())
     }
 
-    pub fn build_with_ancestors_w_rng(self, rng: &impl RandomSource) -> Result<PhyloInfo<AA>> {
+    pub fn build_with_ancestors_w_rng(self, rng: &mut impl RandomSource) -> Result<PhyloInfo<AA>> {
         let sequences = self.read_sequences()?;
         let mut tree = match &self.tree_file {
             Some(tree_file) => self.read_tree(tree_file)?,

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -140,7 +140,7 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
     /// ```
     pub fn build_w_rng<R>(self, rng: &mut RandomGenerator<R>) -> Result<PhyloInfo<A>>
     where
-        R: Rng + SeedableRng + Send,
+        R: Rng + SeedableRng,
     {
         let sequences = self.read_sequences()?;
         let tree = match &self.tree_file {
@@ -171,7 +171,7 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
         rng: &mut RandomGenerator<R>,
     ) -> Result<PhyloInfo<AA>>
     where
-        R: Rng + SeedableRng + Send,
+        R: Rng + SeedableRng,
     {
         let sequences = self.read_sequences()?;
         let mut tree = match &self.tree_file {

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -99,11 +99,11 @@ mod tests {
         // Test new FakeGenerator defaults
         let mut fake_rng = FakeGenerator::default();
         assert_eq!(fake_rng.seed(), 0);
-        let val: u64 = fake_rng.gen();
+        let val: u64 = fake_rng.random();
         assert_eq!(val, 0);
-        let val: f64 = fake_rng.gen();
+        let val: f64 = fake_rng.random();
         assert_eq!(val, 0.0);
-        let val: bool = fake_rng.gen();
+        let val: bool = fake_rng.random();
         assert!(!val);
     }
 
@@ -114,10 +114,10 @@ mod tests {
         let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
         for i in 0..10 {
-            let val: u64 = fake_rng.gen();
+            let val: u64 = fake_rng.random();
             assert_eq!(val, values[i % values.len()]);
         }
-        let val: f64 = fake_rng.gen();
+        let val: f64 = fake_rng.random();
         assert_eq!(val, 0.0); // Default for f64
     }
 
@@ -127,27 +127,27 @@ mod tests {
         let values = vec![5, 6, 7, 8, 9, 14, 15, 16];
         let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
-        let val: u64 = fake_rng.gen();
+        let val: u64 = fake_rng.random();
         assert_eq!(val, values[0]);
-        let val: u32 = fake_rng.gen();
+        let val: u32 = fake_rng.random();
         assert_eq!(val, values[1] as u32);
-        let val: u16 = fake_rng.gen();
+        let val: u16 = fake_rng.random();
         assert_eq!(val, values[2] as u16);
-        let val: u8 = fake_rng.gen();
+        let val: u8 = fake_rng.random();
         assert_eq!(val, values[3] as u8);
-        let val: i64 = fake_rng.gen();
+        let val: i64 = fake_rng.random();
         assert_eq!(val, values[4] as i64);
-        let val: i32 = fake_rng.gen();
+        let val: i32 = fake_rng.random();
         assert_eq!(val, values[5] as i32);
-        let val: i16 = fake_rng.gen();
+        let val: i16 = fake_rng.random();
         assert_eq!(val, values[6] as i16);
-        let val: i8 = fake_rng.gen();
+        let val: i8 = fake_rng.random();
         assert_eq!(val, values[7] as i8);
-        let val: f64 = fake_rng.gen();
+        let val: f64 = fake_rng.random();
         assert_eq!(val, 0.0); // Default for f64
-        let val: f32 = fake_rng.gen();
+        let val: f32 = fake_rng.random();
         assert_eq!(val, 0.0); // Default for f32
-        let val: bool = fake_rng.gen();
+        let val: bool = fake_rng.random();
         assert!(!val); // Default for bool
     }
 
@@ -156,12 +156,12 @@ mod tests {
         // Test that creating new instances with the same values produces the same sequence
         let values = vec![5, 7, 8, 10, 12];
         let mut rng1 = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
-        let val1: u64 = rng1.gen();
-        let val2: u32 = rng1.gen();
+        let val1: u64 = rng1.random();
+        let val2: u32 = rng1.random();
 
         let mut rng2 = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
-        let val1_repeat: u64 = rng2.gen();
-        let val2_repeat: u32 = rng2.gen();
+        let val1_repeat: u64 = rng2.random();
+        let val2_repeat: u32 = rng2.random();
 
         assert_eq!(val1, val1_repeat);
         assert_eq!(val2, val2_repeat);
@@ -174,11 +174,11 @@ mod tests {
         // Test that reseeding does not do anything to an empty FakeGenerator
         let mut fake_rng = FakeGenerator::default();
         assert_eq!(fake_rng.seed(), 0);
-        let val1: u64 = fake_rng.gen();
+        let val1: u64 = fake_rng.random();
 
         fake_rng.reseed(42);
         assert_eq!(fake_rng.seed(), 42);
-        let val1_repeat: u64 = fake_rng.gen();
+        let val1_repeat: u64 = fake_rng.random();
 
         assert_eq!(val1, val1_repeat);
         assert_eq!(val1, 0); // Default value after reseed

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -116,7 +116,7 @@ impl Default for FakeRng {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use approx::assert_relative_eq;
-    use rand::{distr::weighted::WeightedIndex, SeedableRng};
+    use rand::{distr::weighted::WeightedIndex, RngCore, SeedableRng};
 
     use crate::random::{FakeGenerator, RandomGenerator};
 
@@ -326,5 +326,20 @@ mod tests {
         let mid_u64 = 1u64 << 63; // Half of the maximum value when shifted
         let mid_f64 = FakeRng::u64_to_f64_for_rand(mid_u64);
         assert_relative_eq!(mid_f64, 0.5, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_fill_bytes() {
+        let values = vec![0x1122334455667788, 0x99AABBCCDDEEFF00];
+        let mut fake_rng = FakeRng::from_u64_values(values.clone());
+        let mut buffer = [0u8; 16];
+        fake_rng.fill_bytes(&mut buffer);
+
+        let expected_bytes: Vec<u8> = values
+            .iter()
+            .flat_map(|&v| v.to_le_bytes().to_vec())
+            .collect();
+
+        assert_eq!(buffer.to_vec(), expected_bytes);
     }
 }

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -213,15 +213,19 @@ mod tests {
         let mut rng1 = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         let val1: u64 = rng1.random();
         let val2: u32 = rng1.random();
+        let val3: f64 = rng1.random();
 
         let mut rng2 = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         let val1_repeat: u64 = rng2.random();
         let val2_repeat: u32 = rng2.random();
+        let val3_repeat: f64 = rng2.random();
 
         assert_eq!(val1, val1_repeat);
         assert_eq!(val2, val2_repeat);
+        assert_eq!(val3, val3_repeat);
         assert_eq!(val1, values[0]);
         assert_eq!(val2, values[1] as u32);
+        assert_eq!(val3, FakeRng::u64_to_f64_for_rand(values[2]));
     }
 
     #[test]

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -257,6 +257,43 @@ mod tests {
         assert_eq!(rng.sample(&dist), 1);
     }
 
+    #[cfg(test)]
+    fn get_cumulative_index(weights: &[f64], value: f64) -> usize {
+        let total: f64 = weights.iter().sum();
+        let mut cumulative = 0.0;
+        for (i, &weight) in weights.iter().enumerate() {
+            cumulative += weight / total;
+            if value < cumulative {
+                return i;
+            }
+        }
+        weights.len() - 1
+    }
+
+    #[test]
+    fn fake_sample_with_values() {
+        // sampling with pre-configured float values
+        let floats = vec![
+            0.1,
+            0.25,
+            0.5,
+            0.75,
+            0.9,
+            0.99,
+            0.2 - f64::EPSILON,
+            0.2 + f64::EPSILON,
+            1.0,
+            0.0,
+        ];
+        let mut rng = RandomGenerator::from_rng(FakeRng::from_f64_values(floats.clone()));
+        let weights = vec![0.2, 0.35, 0.4, 0.05];
+        let dist = WeightedIndex::new(weights.clone()).unwrap();
+        for value in &floats {
+            let expected = get_cumulative_index(&weights, *value);
+            assert_eq!(rng.sample(&dist), expected);
+        }
+    }
+
     #[test]
     fn fake_from_desired_floats() {
         // Fake RNG that produces specific f64 values

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -51,8 +51,6 @@ impl SeedableRng for FakeRng {
     }
 }
 
-unsafe impl Send for FakeRng {}
-
 impl FakeRng {
     /// Create a new FakeRng with an empty u64 value sequence, will return 0 for every int value
     pub fn new() -> Self {

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -1,5 +1,4 @@
 use std::any::{Any, TypeId};
-use std::sync::Mutex;
 
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
@@ -9,13 +8,13 @@ use crate::random::RandomSource;
 /// A fake random number generator for deterministic testing.
 /// Returns predictable values from pre-configured sequences.
 pub struct FakeGenerator {
-    u64_values: Mutex<Vec<u64>>,
-    f64_values: Mutex<Vec<f64>>,
-    bool_values: Mutex<Vec<bool>>,
-    u64_index: Mutex<usize>,
-    f64_index: Mutex<usize>,
-    bool_index: Mutex<usize>,
-    seed: Mutex<u64>,
+    u64_values: Vec<u64>,
+    f64_values: Vec<f64>,
+    bool_values: Vec<bool>,
+    u64_index: usize,
+    f64_index: usize,
+    bool_index: usize,
+    seed: u64,
 }
 
 macro_rules! fakegen_downcast {
@@ -30,100 +29,91 @@ impl FakeGenerator {
     /// which will default to 0, 0.0, or false if no values are provided
     pub fn new() -> Self {
         Self {
-            u64_values: Mutex::new(Vec::new()),
-            f64_values: Mutex::new(Vec::new()),
-            bool_values: Mutex::new(Vec::new()),
-            u64_index: Mutex::new(0),
-            f64_index: Mutex::new(0),
-            bool_index: Mutex::new(0),
-            seed: Mutex::new(0),
+            u64_values: Vec::new(),
+            f64_values: Vec::new(),
+            bool_values: Vec::new(),
+            u64_index: 0,
+            f64_index: 0,
+            bool_index: 0,
+            seed: 0,
         }
     }
 
     /// Create a FakeGenerator with pre-configured u64 values
     pub fn from_u64_values(values: Vec<u64>) -> Self {
         Self {
-            u64_values: Mutex::new(values),
-            f64_values: Mutex::new(Vec::new()),
-            bool_values: Mutex::new(Vec::new()),
-            u64_index: Mutex::new(0),
-            f64_index: Mutex::new(0),
-            bool_index: Mutex::new(0),
-            seed: Mutex::new(0),
+            u64_values: values,
+            f64_values: Vec::new(),
+            bool_values: Vec::new(),
+            u64_index: 0,
+            f64_index: 0,
+            bool_index: 0,
+            seed: 0,
         }
     }
 
     /// Create a FakeGenerator with pre-configured f64 values
     pub fn from_f64_values(values: Vec<f64>) -> Self {
         Self {
-            u64_values: Mutex::new(Vec::new()),
-            f64_values: Mutex::new(values),
-            bool_values: Mutex::new(Vec::new()),
-            u64_index: Mutex::new(0),
-            f64_index: Mutex::new(0),
-            bool_index: Mutex::new(0),
-            seed: Mutex::new(0),
+            u64_values: Vec::new(),
+            f64_values: values,
+            bool_values: Vec::new(),
+            u64_index: 0,
+            f64_index: 0,
+            bool_index: 0,
+            seed: 0,
         }
     }
 
     /// Add more u64 values to the sequence
-    pub fn add_u64_values(&self, values: Vec<u64>) {
-        let mut u64_values = self.u64_values.lock().unwrap();
-        u64_values.extend(values);
+    pub fn add_u64_values(&mut self, values: Vec<u64>) {
+        self.u64_values.extend(values);
     }
 
     /// Add more f64 values to the sequence
-    pub fn add_f64_values(&self, values: Vec<f64>) {
-        let mut f64_values = self.f64_values.lock().unwrap();
-        f64_values.extend(values);
+    pub fn add_f64_values(&mut self, values: Vec<f64>) {
+        self.f64_values.extend(values);
     }
 
     /// Add more bool values to the sequence
-    pub fn add_bool_values(&self, values: Vec<bool>) {
-        let mut bool_values = self.bool_values.lock().unwrap();
-        bool_values.extend(values);
+    pub fn add_bool_values(&mut self, values: Vec<bool>) {
+        self.bool_values.extend(values);
     }
 
     /// Get the next u64 value, default is 0
-    fn next_u64(&self) -> u64 {
-        let mut index = self.u64_index.lock().unwrap();
-        let values = self.u64_values.lock().unwrap();
-        if values.is_empty() {
+    fn next_u64(&mut self) -> u64 {
+        if self.u64_values.is_empty() {
             0
         } else {
-            let value = values[*index % values.len()];
-            *index += 1;
+            let value = self.u64_values[self.u64_index % self.u64_values.len()];
+            self.u64_index += 1;
             value
         }
     }
 
     /// Get the next f64 value, default is 0.0
-    fn next_f64(&self) -> f64 {
-        let mut index = self.f64_index.lock().unwrap();
-        let values = self.f64_values.lock().unwrap();
-        if values.is_empty() {
+    fn next_f64(&mut self) -> f64 {
+        if self.f64_values.is_empty() {
             0.0
         } else {
-            let value = values[*index % values.len()];
-            *index += 1;
+            let value = self.f64_values[self.f64_index % self.f64_values.len()];
+            self.f64_index += 1;
             value
         }
     }
 
     /// Get the next bool value, default is false
-    fn next_bool(&self) -> bool {
-        let mut index = self.bool_index.lock().unwrap();
-        let values = self.bool_values.lock().unwrap();
-        if values.is_empty() {
+    fn next_bool(&mut self) -> bool {
+        if self.bool_values.is_empty() {
             false
         } else {
-            let value = values[*index % values.len()];
-            *index += 1;
+            let value = self.bool_values[self.bool_index % self.bool_values.len()];
+            self.bool_index += 1;
             value
         }
     }
 
-    fn next_value<T>(&self) -> T
+    fn next_value<T>(&mut self) -> T
     where
         T: 'static,
     {
@@ -177,11 +167,10 @@ impl Default for FakeGenerator {
 impl RandomSource for FakeGenerator {
     fn seed(&self) -> u64 {
         // The seed is irrelevant for FakeGenerator, but we implement it for compatibility
-        let seed = self.seed.lock().unwrap();
-        *seed
+        self.seed
     }
 
-    fn gen<T>(&self) -> T
+    fn gen<T>(&mut self) -> T
     where
         T: 'static,
         Standard: Distribution<T>,
@@ -189,28 +178,28 @@ impl RandomSource for FakeGenerator {
         self.next_value()
     }
 
-    fn gen_bool(&self, _p: f64) -> bool {
+    fn gen_bool(&mut self, _p: f64) -> bool {
         self.next_bool()
     }
 
-    fn gen_probability(&self) -> f64 {
+    fn gen_probability(&mut self) -> f64 {
         let val = self.next_f64();
         val.clamp(0.0, 1.0)
     }
 
-    fn shuffle<T>(&self, _slice: &mut [T]) {
+    fn shuffle<T>(&mut self, _slice: &mut [T]) {
         // No shuffling for fake generator
     }
 
-    fn reseed(&self, seed: u64) {
+    fn reseed(&mut self, seed: u64) {
         // Reseeding resets the indices
-        *self.u64_index.lock().unwrap() = 0;
-        *self.f64_index.lock().unwrap() = 0;
-        *self.bool_index.lock().unwrap() = 0;
-        *self.seed.lock().unwrap() = seed;
+        self.u64_index = 0;
+        self.f64_index = 0;
+        self.bool_index = 0;
+        self.seed = seed;
     }
 
-    fn sample<D, T>(&self, _dist: &D) -> T
+    fn sample<D, T>(&mut self, _dist: &D) -> T
     where
         T: 'static,
         D: Distribution<T>,
@@ -232,7 +221,7 @@ mod tests {
     #[test]
     fn fake_rng_defaults() {
         // Test new FakeGenerator defaults
-        let fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::new();
         assert_eq!(fake_rng.seed(), 0);
         let val: u64 = fake_rng.gen();
         assert_eq!(val, 0);
@@ -245,7 +234,7 @@ mod tests {
     fn fake_rng_with_values() {
         // Test FakeGenerator with pre-configured values
         let values = (15..25).collect::<Vec<u64>>();
-        let fake_rng = FakeGenerator::from_u64_values(values.clone());
+        let mut fake_rng = FakeGenerator::from_u64_values(values.clone());
         assert_eq!(fake_rng.seed(), 0);
         for i in 0..10 {
             let val: u64 = fake_rng.gen();
@@ -260,7 +249,7 @@ mod tests {
     #[should_panic(expected = "FakeGenerator doesn't support type")]
     fn fake_rng_panic() {
         // Test that FakeGenerator panics for an unsupported type (isize)
-        let fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::new();
         fake_rng.gen::<isize>();
     }
 
@@ -268,7 +257,7 @@ mod tests {
     fn fake_rng_gen_bool() {
         // Test that p makes no difference for gen_bool in FakeGenerator
         let values = vec![true, false, true, false];
-        let fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::new();
         fake_rng.add_bool_values(values.clone());
         for i in 0..10 {
             assert_eq!(fake_rng.gen_bool(0.3), values[i % values.len()]);
@@ -283,7 +272,7 @@ mod tests {
     fn fake_rng_with_diff_types() {
         // Test FakeGenerator with different value types
         let values = vec![5, 6, 7, 8, 9, 14, 15, 16, 17, 18, 33];
-        let fake_rng = FakeGenerator::from_u64_values(values.clone());
+        let mut fake_rng = FakeGenerator::from_u64_values(values.clone());
         assert_eq!(fake_rng.seed(), 0);
         let val: usize = fake_rng.gen();
         assert_eq!(val, values[0] as usize);
@@ -317,11 +306,11 @@ mod tests {
     fn fake_rng_reproducibility() {
         // Test that creating new instances with the same values produces the same sequence
         let values = vec![0.1, 0.2, 0.3];
-        let rng1 = FakeGenerator::from_f64_values(values.clone());
+        let mut rng1 = FakeGenerator::from_f64_values(values.clone());
         let val1: f64 = rng1.gen();
         let val2: f32 = rng1.gen();
 
-        let rng2 = FakeGenerator::from_f64_values(values);
+        let mut rng2 = FakeGenerator::from_f64_values(values);
         let val1_repeat: f64 = rng2.gen();
         let val2_repeat: f32 = rng2.gen();
 
@@ -332,7 +321,7 @@ mod tests {
     #[test]
     fn fake_reseed_empty() {
         // Test that reseeding does not do anything to an empty FakeGenerator
-        let fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::new();
         assert_eq!(fake_rng.seed(), 0);
         let val1: f64 = fake_rng.gen();
 
@@ -348,7 +337,7 @@ mod tests {
     fn fake_reseed_with_values() {
         // Test that reseeding resets pre-configured value counters
         let values = vec![0.1, 0.2, 0.3, 0.4];
-        let fake_rng = FakeGenerator::from_f64_values(values.clone());
+        let mut fake_rng = FakeGenerator::from_f64_values(values.clone());
         let val1: f64 = fake_rng.gen();
         for i in 1..10 {
             let val: f64 = fake_rng.gen();
@@ -363,7 +352,7 @@ mod tests {
 
     #[test]
     fn fake_add_values_f64() {
-        let fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::new();
         let values = vec![0.1, 0.2, 0.3, 0.4];
         fake_rng.add_f64_values(values.clone());
         for value in values.iter() {
@@ -379,7 +368,7 @@ mod tests {
 
     #[test]
     fn fake_add_more_values_f64() {
-        let fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::new();
         let values = vec![0.1, 0.2, 0.3, 0.4];
         fake_rng.add_f64_values(values.clone());
         for value in values.iter() {
@@ -401,7 +390,7 @@ mod tests {
 
     #[test]
     fn fake_add_values_u64() {
-        let fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::new();
         let values = (1..10).collect::<Vec<u64>>();
         fake_rng.add_u64_values(values.clone());
         for value in values.iter() {
@@ -417,7 +406,7 @@ mod tests {
 
     #[test]
     fn fake_add_values_bool() {
-        let fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::new();
         let source = vec![true, false, true, false];
         fake_rng.add_bool_values(source.clone());
         for value in source.iter() {
@@ -435,7 +424,7 @@ mod tests {
     #[test]
     fn fake_rng_probabilities() {
         let values = vec![0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 4.0, 5.0];
-        let fake_rng = FakeGenerator::from_f64_values(values.clone());
+        let mut fake_rng = FakeGenerator::from_f64_values(values.clone());
         for _value in values.iter() {
             assert!((0.0..=1.0).contains(&fake_rng.gen_probability()));
         }
@@ -443,16 +432,16 @@ mod tests {
 
     #[test]
     fn fake_different_values() {
-        let fake_rng = FakeGenerator::from_f64_values(vec![0.1, 0.2, 0.3]);
+        let mut fake_rng = FakeGenerator::from_f64_values(vec![0.1, 0.2, 0.3]);
         let val1: f64 = fake_rng.gen();
-        let fake_rng2 = FakeGenerator::from_f64_values(vec![0.4, 0.5, 0.6]);
+        let mut fake_rng2 = FakeGenerator::from_f64_values(vec![0.4, 0.5, 0.6]);
         let val2: f64 = fake_rng2.gen();
         assert_ne!(val1, val2);
     }
 
     #[test]
     fn fake_shuffle() {
-        let rng = FakeGenerator::new();
+        let mut rng = FakeGenerator::new();
         let mut vec = vec![1, 2, 3, 4, 5];
         let original_vec = vec.clone();
         rng.shuffle(&mut vec);
@@ -461,14 +450,14 @@ mod tests {
 
     #[test]
     fn fake_sample_default() {
-        let rng = FakeGenerator::new();
+        let mut rng = FakeGenerator::new();
         let dist = WeightedIndex::new([1.0, 2.0, 3.0]).unwrap();
         assert_eq!(rng.sample(&dist), 0);
     }
 
     #[test]
     fn fake_sample() {
-        let rng = FakeGenerator::from_u64_values(vec![2, 0, 1]);
+        let mut rng = FakeGenerator::from_u64_values(vec![2, 0, 1]);
         let dist = WeightedIndex::new([1.0, 2.0, 3.0]).unwrap();
         assert_eq!(rng.sample(&dist), 2);
         assert_eq!(rng.sample(&dist), 0);

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -138,32 +138,22 @@ mod tests {
     }
 
     #[test]
-    fn fake_rng_from_seed() {
-        // Test new FakeGenerator from seed (seed makes no difference)
+    fn fake_rng_creation() {
+        // Test new FakeGenerator creation with and without seed (seed makes no difference)
         let fake1 = RandomGenerator::from_rng(FakeRng::seed_from_u64(42));
         let fake2 = RandomGenerator::from_rng(FakeRng::from_seed([42; 8]));
         let fake3 = RandomGenerator::from_rng(FakeRng::new());
-        let fake4 = FakeGenerator::default();
+        let fake4 = RandomGenerator::from_rng(FakeRng::default());
+        let fake5 = FakeGenerator::default();
         assert_eq!(fake1.seed(), 0);
         assert_eq!(fake2.seed(), 0);
         assert_eq!(fake3.seed(), 0);
         assert_eq!(fake4.seed(), 0);
+        assert_eq!(fake5.seed(), 0);
         assert_eq!(fake1, fake2);
         assert_eq!(fake1, fake3);
         assert_eq!(fake1, fake4);
-    }
-
-    #[test]
-    fn fake_generator_defaults() {
-        // Test FakeGenerator defaults
-        let mut fake_rng = FakeGenerator::default();
-        assert_eq!(fake_rng.seed(), 0);
-        let val: u64 = fake_rng.random();
-        assert_eq!(val, 0);
-        let val: f64 = fake_rng.random();
-        assert_eq!(val, 0.0);
-        let val: bool = fake_rng.random();
-        assert!(!val);
+        assert_eq!(fake1, fake5);
     }
 
     #[test]

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -67,6 +67,31 @@ impl FakeRng {
             u64_index: 0,
         }
     }
+    /// Create a FakeRng that produces specific f64 values using the same transformation of values as rand's
+    /// Standard distribution
+    pub fn from_f64_values(values: Vec<f64>) -> Self {
+        let u64_values = values
+            .iter()
+            .map(|&f| Self::f64_to_u64_for_rand(f))
+            .collect::<Vec<u64>>();
+        Self {
+            u64_values,
+            u64_index: 0,
+        }
+    }
+
+    fn f64_to_u64_for_rand(f: f64) -> u64 {
+        let clamped = f.clamp(0.0, 1.0 - f64::EPSILON);
+        let scaled = clamped * (1u64 << 53) as f64;
+        (scaled as u64) << 11
+    }
+
+    /// Convert u64 to f64 using the same algorithm as rand's Standard distribution
+    #[cfg(test)]
+    fn u64_to_f64_for_rand(u: u64) -> f64 {
+        // This mirrors the rand crate's conversion: (u64 >> 11) as f64 * (1.0 / (1u64 << 53) as f64)
+        ((u >> 11) as f64) * (1.0 / ((1u64 << 53) as f64))
+    }
 
     /// Get the next u64 value, default is 0
     fn next_u64_value(&mut self) -> u64 {
@@ -89,6 +114,7 @@ impl Default for FakeRng {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
+    use approx::assert_relative_eq;
     use rand::{distr::weighted::WeightedIndex, SeedableRng};
 
     use crate::random::{FakeGenerator, RandomGenerator};
@@ -154,7 +180,7 @@ mod tests {
     #[test]
     fn fake_rng_with_diff_types() {
         // Test FakeGenerator with different value types
-        let values = vec![5, 6, 7, 8, 9, 14, 15, 16];
+        let values = vec![5, 6, 7, 8, 9, 14, 15, 16, u64::MAX];
         let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
         let val: u64 = fake_rng.random();
@@ -174,11 +200,7 @@ mod tests {
         let val: i8 = fake_rng.random();
         assert_eq!(val, values[7] as i8);
         let val: f64 = fake_rng.random();
-        assert_eq!(val, 0.0); // Default for f64
-        let val: f32 = fake_rng.random();
-        assert_eq!(val, 0.0); // Default for f32
-        let val: bool = fake_rng.random();
-        assert!(!val); // Default for bool
+        assert_eq!(val, FakeRng::u64_to_f64_for_rand(values[8]));
     }
 
     #[test]
@@ -236,5 +258,39 @@ mod tests {
         assert_eq!(rng.sample(&dist), 1);
         assert_eq!(rng.sample(&dist), 1);
         assert_eq!(rng.sample(&dist), 1);
+    }
+
+    #[test]
+    fn fake_from_desired_floats() {
+        // Fake RNG that produces specific f64 values
+        let floats = vec![0.1, 0.25, 0.5, 0.75, 0.9];
+        let mut rng = RandomGenerator::from_rng(FakeRng::from_f64_values(floats.clone()));
+        for expected in floats {
+            assert_relative_eq!(rng.random::<f64>(), expected);
+        }
+    }
+
+    #[test]
+    fn test_f64_u64_roundtrip() {
+        // Test that f64 -> u64 -> f64 conversion preserves values within floating point precision
+        let test_values = vec![0.0, 0.1, 0.25, 0.333333, 0.5, 0.666666, 0.75, 0.9, 0.999999];
+
+        for original in test_values {
+            let u64_val = FakeRng::f64_to_u64_for_rand(original);
+            let roundtrip = FakeRng::u64_to_f64_for_rand(u64_val);
+            assert_relative_eq!(original, roundtrip, epsilon = 1e-15);
+        }
+    }
+
+    #[test]
+    fn test_u64_to_f64_conversion() {
+        // Test specific u64 values to ensure they produce expected f64 values
+        assert_relative_eq!(FakeRng::u64_to_f64_for_rand(0), 0.0);
+        assert_relative_eq!(FakeRng::u64_to_f64_for_rand(u64::MAX), 1.0 - f64::EPSILON);
+
+        // Test the middle value
+        let mid_u64 = 1u64 << 63; // Half of the maximum value when shifted
+        let mid_f64 = FakeRng::u64_to_f64_for_rand(mid_u64);
+        assert_relative_eq!(mid_f64, 0.5, epsilon = 1e-15);
     }
 }

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -97,6 +97,19 @@ mod tests {
     #[test]
     fn fake_rng_defaults() {
         // Test new FakeGenerator defaults
+        let mut fake_rng = FakeGenerator::from_rng(FakeRng::default());
+        assert_eq!(fake_rng.seed(), 0);
+        let val: u64 = fake_rng.random();
+        assert_eq!(val, 0);
+        let val: f64 = fake_rng.random();
+        assert_eq!(val, 0.0);
+        let val: bool = fake_rng.random();
+        assert!(!val);
+    }
+
+    #[test]
+    fn fake_generator_defaults() {
+        // Test new FakeGenerator defaults
         let mut fake_rng = FakeGenerator::default();
         assert_eq!(fake_rng.seed(), 0);
         let val: u64 = fake_rng.random();

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -89,7 +89,7 @@ impl Default for FakeRng {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    use rand::distr::weighted::WeightedIndex;
+    use rand::{distr::weighted::WeightedIndex, SeedableRng};
 
     use crate::random::{FakeGenerator, RandomGenerator};
 
@@ -106,6 +106,22 @@ mod tests {
         assert_eq!(val, 0.0);
         let val: bool = fake_rng.random();
         assert!(!val);
+    }
+
+    #[test]
+    fn fake_rng_from_seed() {
+        // Test new FakeGenerator from seed (seed makes no difference)
+        let fake1 = RandomGenerator::from_rng(FakeRng::seed_from_u64(42));
+        let fake2 = RandomGenerator::from_rng(FakeRng::from_seed([42; 8]));
+        let fake3 = RandomGenerator::from_rng(FakeRng::new());
+        let fake4 = FakeGenerator::default();
+        assert_eq!(fake1.seed(), 0);
+        assert_eq!(fake2.seed(), 0);
+        assert_eq!(fake3.seed(), 0);
+        assert_eq!(fake4.seed(), 0);
+        assert_eq!(fake1, fake2);
+        assert_eq!(fake1, fake3);
+        assert_eq!(fake1, fake4);
     }
 
     #[test]

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -2,7 +2,9 @@ use rand::{RngCore, SeedableRng};
 
 /// A fake random number generator for deterministic testing.
 /// Can return pre-configured values for unsigned (usize, u64, u32, u16, u8) and
-/// signed (isize, i64, i32, i16, i8) integer types, and defaults to 0, 0.0, or false for other types.
+/// signed (isize, i64, i32, i16, i8) integer types.
+/// Can also be set up to produce specific f64 values (up to floating point precision).
+/// If no pre-configured values are provided, it will return 0 for all integer types and 0.0 for f64.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FakeRng {
     u64_values: Vec<u64>,
@@ -80,6 +82,7 @@ impl FakeRng {
         }
     }
 
+    /// Convert f64 to u64 using the same algorithm as rand's Standard distribution
     fn f64_to_u64_for_rand(f: f64) -> u64 {
         let clamped = f.clamp(0.0, 1.0 - f64::EPSILON);
         let scaled = clamped * (1u64 << 53) as f64;
@@ -165,7 +168,7 @@ mod tests {
 
     #[test]
     fn fake_rng_with_u64_values() {
-        // Test FakeGenerator with pre-configured values
+        // FakeRng with pre-configured values
         let values = (15..25).collect::<Vec<u64>>();
         let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
@@ -174,12 +177,12 @@ mod tests {
             assert_eq!(val, values[i % values.len()]);
         }
         let val: f64 = fake_rng.random();
-        assert_eq!(val, 0.0); // Default for f64
+        assert_eq!(val, FakeRng::u64_to_f64_for_rand(values[0]));
     }
 
     #[test]
     fn fake_rng_with_diff_types() {
-        // Test FakeGenerator with different value types
+        // FakeRng with different value types
         let values = vec![5, 6, 7, 8, 9, 14, 15, 16, u64::MAX];
         let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
@@ -205,7 +208,7 @@ mod tests {
 
     #[test]
     fn fake_rng_reproducibility() {
-        // Test that creating new instances with the same values produces the same sequence
+        // creating new instances with the same values produces the same sequence
         let values = vec![5, 7, 8, 10, 12];
         let mut rng1 = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         let val1: u64 = rng1.random();
@@ -223,7 +226,7 @@ mod tests {
 
     #[test]
     fn fake_reseed_empty() {
-        // Test that reseeding does not do anything to an empty FakeGenerator
+        // reseeding does not do anything to an empty FakeGenerator
         let mut fake_rng = FakeGenerator::default();
         assert_eq!(fake_rng.seed(), 0);
         let val1: u64 = fake_rng.random();
@@ -246,6 +249,7 @@ mod tests {
 
     #[test]
     fn fake_sample_default() {
+        // always returns first non-zero index when no pre-configured values
         let mut rng = FakeGenerator::default();
         let dist = WeightedIndex::new([1.0, 2.0, 3.0]).unwrap();
         assert_eq!(rng.sample(&dist), 0);
@@ -253,6 +257,7 @@ mod tests {
 
     #[test]
     fn fake_sample() {
+        // always returns first non-zero index when no pre-configured values
         let mut rng = FakeGenerator::default();
         let dist = WeightedIndex::new([0.0, 3.0, 2.0, 1.0, 2.0]).unwrap();
         assert_eq!(rng.sample(&dist), 1);
@@ -272,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_f64_u64_roundtrip() {
-        // Test that f64 -> u64 -> f64 conversion preserves values within floating point precision
+        // f64 -> u64 -> f64 conversion preserves values within floating point precision
         let test_values = vec![0.0, 0.1, 0.25, 0.333333, 0.5, 0.666666, 0.75, 0.9, 0.999999];
 
         for original in test_values {
@@ -284,11 +289,11 @@ mod tests {
 
     #[test]
     fn test_u64_to_f64_conversion() {
-        // Test specific u64 values to ensure they produce expected f64 values
+        // specific u64 values produce expected f64 values
         assert_relative_eq!(FakeRng::u64_to_f64_for_rand(0), 0.0);
         assert_relative_eq!(FakeRng::u64_to_f64_for_rand(u64::MAX), 1.0 - f64::EPSILON);
 
-        // Test the middle value
+        // middle value
         let mid_u64 = 1u64 << 63; // Half of the maximum value when shifted
         let mid_f64 = FakeRng::u64_to_f64_for_rand(mid_u64);
         assert_relative_eq!(mid_f64, 0.5, epsilon = 1e-15);

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -162,7 +162,7 @@ mod tests {
         let values = (15..25).collect::<Vec<u64>>();
         let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
-        for i in 0..10 {
+        for i in 0..30 {
             let val: u64 = fake_rng.random();
             assert_eq!(val, values[i % values.len()]);
         }

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -3,6 +3,7 @@ use rand::{RngCore, SeedableRng};
 /// A fake random number generator for deterministic testing.
 /// Can return pre-configured values for unsigned (usize, u64, u32, u16, u8) and
 /// signed (isize, i64, i32, i16, i8) integer types, and defaults to 0, 0.0, or false for other types.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FakeRng {
     u64_values: Vec<u64>,
     u64_index: usize,

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -1,87 +1,79 @@
-use std::any::{Any, TypeId};
-
-use rand::distributions::Standard;
-use rand::prelude::Distribution;
-
-use crate::random::RandomSource;
+use rand::{Error, RngCore, SeedableRng};
 
 /// A fake random number generator for deterministic testing.
-/// Returns predictable values from pre-configured sequences.
-pub struct FakeGenerator {
+/// Can return pre-configured values for unsigned (usize, u64, u32, u16, u8) and
+/// signed (isize, i64, i32, i16, i8) integer types, and defaults to 0, 0.0, or false for other types.
+pub struct FakeRng {
     u64_values: Vec<u64>,
-    f64_values: Vec<f64>,
-    bool_values: Vec<bool>,
     u64_index: usize,
-    f64_index: usize,
-    bool_index: usize,
-    seed: u64,
 }
 
-macro_rules! fakegen_downcast {
-    ($val:expr) => {{
-        let boxed: Box<dyn Any> = Box::new($val);
-        *boxed.downcast::<T>().unwrap()
-    }};
+impl RngCore for FakeRng {
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64_value() as u32
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.next_u64_value()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        // Fill the byte array with values from the saved u64 sequence
+        for chunk in dest.chunks_mut(8) {
+            let value = self.next_u64_value();
+            let bytes = value.to_le_bytes();
+            for (i, byte) in chunk.iter_mut().enumerate() {
+                *byte = bytes[i];
+            }
+        }
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
 }
 
-impl FakeGenerator {
-    /// Create a new FakeGenerator with empty value sequences,
-    /// which will default to 0, 0.0, or false if no values are provided
+// Implement SeedableRng but the seed is ignored since this is a fake RNG
+impl SeedableRng for FakeRng {
+    type Seed = [u8; 8];
+
+    fn from_seed(_: Self::Seed) -> Self {
+        Self {
+            u64_values: Vec::new(),
+            u64_index: 0,
+        }
+    }
+
+    fn seed_from_u64(_: u64) -> Self {
+        Self {
+            u64_values: Vec::new(),
+            u64_index: 0,
+        }
+    }
+}
+
+unsafe impl Send for FakeRng {}
+
+impl FakeRng {
+    /// Create a new FakeRng with an empty u64 value sequence, will return 0 for every int value
     pub fn new() -> Self {
         Self {
             u64_values: Vec::new(),
-            f64_values: Vec::new(),
-            bool_values: Vec::new(),
             u64_index: 0,
-            f64_index: 0,
-            bool_index: 0,
-            seed: 0,
         }
     }
 
-    /// Create a FakeGenerator with pre-configured u64 values
+    /// Create a FakeRng with pre-configured u64 values
     pub fn from_u64_values(values: Vec<u64>) -> Self {
         Self {
             u64_values: values,
-            f64_values: Vec::new(),
-            bool_values: Vec::new(),
             u64_index: 0,
-            f64_index: 0,
-            bool_index: 0,
-            seed: 0,
         }
-    }
-
-    /// Create a FakeGenerator with pre-configured f64 values
-    pub fn from_f64_values(values: Vec<f64>) -> Self {
-        Self {
-            u64_values: Vec::new(),
-            f64_values: values,
-            bool_values: Vec::new(),
-            u64_index: 0,
-            f64_index: 0,
-            bool_index: 0,
-            seed: 0,
-        }
-    }
-
-    /// Add more u64 values to the sequence
-    pub fn add_u64_values(&mut self, values: Vec<u64>) {
-        self.u64_values.extend(values);
-    }
-
-    /// Add more f64 values to the sequence
-    pub fn add_f64_values(&mut self, values: Vec<f64>) {
-        self.f64_values.extend(values);
-    }
-
-    /// Add more bool values to the sequence
-    pub fn add_bool_values(&mut self, values: Vec<bool>) {
-        self.bool_values.extend(values);
     }
 
     /// Get the next u64 value, default is 0
-    fn next_u64(&mut self) -> u64 {
+    fn next_u64_value(&mut self) -> u64 {
         if self.u64_values.is_empty() {
             0
         } else {
@@ -90,122 +82,11 @@ impl FakeGenerator {
             value
         }
     }
-
-    /// Get the next f64 value, default is 0.0
-    fn next_f64(&mut self) -> f64 {
-        if self.f64_values.is_empty() {
-            0.0
-        } else {
-            let value = self.f64_values[self.f64_index % self.f64_values.len()];
-            self.f64_index += 1;
-            value
-        }
-    }
-
-    /// Get the next bool value, default is false
-    fn next_bool(&mut self) -> bool {
-        if self.bool_values.is_empty() {
-            false
-        } else {
-            let value = self.bool_values[self.bool_index % self.bool_values.len()];
-            self.bool_index += 1;
-            value
-        }
-    }
-
-    fn next_value<T>(&mut self) -> T
-    where
-        T: 'static,
-    {
-        // Safe implementation using downcasting
-        let type_id = TypeId::of::<T>();
-        // Create the appropriate value based on the type
-        if type_id == TypeId::of::<u64>() {
-            fakegen_downcast!(self.next_u64())
-        } else if type_id == TypeId::of::<usize>() {
-            fakegen_downcast!(self.next_u64() as usize)
-        } else if type_id == TypeId::of::<u32>() {
-            fakegen_downcast!(self.next_u64() as u32)
-        } else if type_id == TypeId::of::<u16>() {
-            fakegen_downcast!(self.next_u64() as u16)
-        } else if type_id == TypeId::of::<u8>() {
-            fakegen_downcast!(self.next_u64() as u8)
-        } else if type_id == TypeId::of::<char>() {
-            fakegen_downcast!(self.next_u64() as u8 as char)
-        } else if type_id == TypeId::of::<i128>() {
-            fakegen_downcast!(self.next_u64() as i128)
-        } else if type_id == TypeId::of::<i64>() {
-            fakegen_downcast!(self.next_u64() as i64)
-        } else if type_id == TypeId::of::<i32>() {
-            fakegen_downcast!(self.next_u64() as i32)
-        } else if type_id == TypeId::of::<i16>() {
-            fakegen_downcast!(self.next_u64() as i16)
-        } else if type_id == TypeId::of::<i8>() {
-            fakegen_downcast!(self.next_u64() as i8)
-        } else if type_id == TypeId::of::<f64>() {
-            fakegen_downcast!(self.next_f64())
-        } else if type_id == TypeId::of::<f32>() {
-            fakegen_downcast!(self.next_f64() as f32)
-        } else if type_id == TypeId::of::<bool>() {
-            fakegen_downcast!(self.next_bool())
-        } else {
-            // For unknown types, immediately panic with an error
-            panic!(
-                "FakeGenerator doesn't support type {:?}",
-                std::any::type_name::<T>()
-            )
-        }
-    }
 }
 
-impl Default for FakeGenerator {
+impl Default for FakeRng {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl RandomSource for FakeGenerator {
-    fn seed(&self) -> u64 {
-        // The seed is irrelevant for FakeGenerator, but we implement it for compatibility
-        self.seed
-    }
-
-    fn gen<T>(&mut self) -> T
-    where
-        T: 'static,
-        Standard: Distribution<T>,
-    {
-        self.next_value()
-    }
-
-    fn gen_bool(&mut self, _p: f64) -> bool {
-        self.next_bool()
-    }
-
-    fn gen_probability(&mut self) -> f64 {
-        let val = self.next_f64();
-        val.clamp(0.0, 1.0)
-    }
-
-    fn shuffle<T>(&mut self, _slice: &mut [T]) {
-        // No shuffling for fake generator
-    }
-
-    fn reseed(&mut self, seed: u64) {
-        // Reseeding resets the indices
-        self.u64_index = 0;
-        self.f64_index = 0;
-        self.bool_index = 0;
-        self.seed = seed;
-    }
-
-    fn sample<D, T>(&mut self, _dist: &D) -> T
-    where
-        T: 'static,
-        D: Distribution<T>,
-    {
-        // Will return indices provided as input, cannot check if index is within range
-        self.next_value()
     }
 }
 
@@ -214,27 +95,28 @@ impl RandomSource for FakeGenerator {
 mod tests {
     use rand::distributions::WeightedIndex;
 
-    use crate::random::RandomSource;
+    use crate::random::{FakeGenerator, RandomGenerator};
 
-    use super::*;
+    use super::FakeRng;
 
     #[test]
     fn fake_rng_defaults() {
         // Test new FakeGenerator defaults
-        let mut fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::default();
         assert_eq!(fake_rng.seed(), 0);
         let val: u64 = fake_rng.gen();
         assert_eq!(val, 0);
         let val: f64 = fake_rng.gen();
         assert_eq!(val, 0.0);
-        assert!(!fake_rng.gen::<bool>());
+        let val: bool = fake_rng.gen();
+        assert!(!val);
     }
 
     #[test]
-    fn fake_rng_with_values() {
+    fn fake_rng_with_u64_values() {
         // Test FakeGenerator with pre-configured values
         let values = (15..25).collect::<Vec<u64>>();
-        let mut fake_rng = FakeGenerator::from_u64_values(values.clone());
+        let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
         for i in 0..10 {
             let val: u64 = fake_rng.gen();
@@ -242,37 +124,13 @@ mod tests {
         }
         let val: f64 = fake_rng.gen();
         assert_eq!(val, 0.0); // Default for f64
-        assert!(!fake_rng.gen::<bool>()); // Default for bool
-    }
-
-    #[test]
-    #[should_panic(expected = "FakeGenerator doesn't support type")]
-    fn fake_rng_panic() {
-        // Test that FakeGenerator panics for an unsupported type (isize)
-        let mut fake_rng = FakeGenerator::new();
-        fake_rng.gen::<isize>();
-    }
-
-    #[test]
-    fn fake_rng_gen_bool() {
-        // Test that p makes no difference for gen_bool in FakeGenerator
-        let values = vec![true, false, true, false];
-        let mut fake_rng = FakeGenerator::new();
-        fake_rng.add_bool_values(values.clone());
-        for i in 0..10 {
-            assert_eq!(fake_rng.gen_bool(0.3), values[i % values.len()]);
-        }
-        fake_rng.reseed(0);
-        for i in 0..10 {
-            assert_eq!(fake_rng.gen_bool(0.7), values[i % values.len()]);
-        }
     }
 
     #[test]
     fn fake_rng_with_diff_types() {
         // Test FakeGenerator with different value types
-        let values = vec![5, 6, 7, 8, 9, 14, 15, 16, 17, 18, 33];
-        let mut fake_rng = FakeGenerator::from_u64_values(values.clone());
+        let values = vec![5, 6, 7, 8, 9, 14, 15, 16, 17, 18];
+        let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
         let val: usize = fake_rng.gen();
         assert_eq!(val, values[0] as usize);
@@ -284,8 +142,8 @@ mod tests {
         assert_eq!(val, values[3] as u16);
         let val: u8 = fake_rng.gen();
         assert_eq!(val, values[4] as u8);
-        let val: i128 = fake_rng.gen();
-        assert_eq!(val, values[5] as i128);
+        let val: isize = fake_rng.gen();
+        assert_eq!(val, values[5] as isize);
         let val: i64 = fake_rng.gen();
         assert_eq!(val, values[6] as i64);
         let val: i32 = fake_rng.gen();
@@ -294,10 +152,10 @@ mod tests {
         assert_eq!(val, values[8] as i16);
         let val: i8 = fake_rng.gen();
         assert_eq!(val, values[9] as i8);
-        let val: char = fake_rng.gen();
-        assert_eq!(val, values[10] as u8 as char);
         let val: f64 = fake_rng.gen();
         assert_eq!(val, 0.0); // Default for f64
+        let val: f32 = fake_rng.gen();
+        assert_eq!(val, 0.0); // Default for f32
         let val: bool = fake_rng.gen();
         assert!(!val); // Default for bool
     }
@@ -305,162 +163,57 @@ mod tests {
     #[test]
     fn fake_rng_reproducibility() {
         // Test that creating new instances with the same values produces the same sequence
-        let values = vec![0.1, 0.2, 0.3];
-        let mut rng1 = FakeGenerator::from_f64_values(values.clone());
-        let val1: f64 = rng1.gen();
-        let val2: f32 = rng1.gen();
+        let values = vec![5, 7, 8, 10, 12];
+        let mut rng1 = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
+        let val1: u64 = rng1.gen();
+        let val2: u32 = rng1.gen();
 
-        let mut rng2 = FakeGenerator::from_f64_values(values);
-        let val1_repeat: f64 = rng2.gen();
-        let val2_repeat: f32 = rng2.gen();
+        let mut rng2 = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
+        let val1_repeat: u64 = rng2.gen();
+        let val2_repeat: u32 = rng2.gen();
 
         assert_eq!(val1, val1_repeat);
         assert_eq!(val2, val2_repeat);
+        assert_eq!(val1, values[0]);
+        assert_eq!(val2, values[1] as u32);
     }
 
     #[test]
     fn fake_reseed_empty() {
         // Test that reseeding does not do anything to an empty FakeGenerator
-        let mut fake_rng = FakeGenerator::new();
+        let mut fake_rng = FakeGenerator::default();
         assert_eq!(fake_rng.seed(), 0);
-        let val1: f64 = fake_rng.gen();
+        let val1: u64 = fake_rng.gen();
 
         fake_rng.reseed(42);
         assert_eq!(fake_rng.seed(), 42);
-        let val1_repeat: f64 = fake_rng.gen();
+        let val1_repeat: u64 = fake_rng.gen();
 
         assert_eq!(val1, val1_repeat);
-        assert_eq!(val1, 0.0); // Default value after reseed
-    }
-
-    #[test]
-    fn fake_reseed_with_values() {
-        // Test that reseeding resets pre-configured value counters
-        let values = vec![0.1, 0.2, 0.3, 0.4];
-        let mut fake_rng = FakeGenerator::from_f64_values(values.clone());
-        let val1: f64 = fake_rng.gen();
-        for i in 1..10 {
-            let val: f64 = fake_rng.gen();
-            assert_eq!(val, values[i % values.len()]);
-        }
-
-        fake_rng.reseed(42);
-        let val1_repeat: f64 = fake_rng.gen();
-        assert_eq!(val1, val1_repeat);
-        assert_eq!(val1, values[0]); // Should return to the first value after reseed
-    }
-
-    #[test]
-    fn fake_add_values_f64() {
-        let mut fake_rng = FakeGenerator::new();
-        let values = vec![0.1, 0.2, 0.3, 0.4];
-        fake_rng.add_f64_values(values.clone());
-        for value in values.iter() {
-            let val: f64 = fake_rng.gen();
-            assert_eq!(val, *value);
-        }
-        let val: f64 = fake_rng.gen();
-        assert_eq!(val, values[0]); // Wraps around
-        let val: u64 = fake_rng.gen();
-        assert_eq!(val, 0); // Default for u64
-        assert!(!fake_rng.gen::<bool>()); // Default for bool
-    }
-
-    #[test]
-    fn fake_add_more_values_f64() {
-        let mut fake_rng = FakeGenerator::new();
-        let values = vec![0.1, 0.2, 0.3, 0.4];
-        fake_rng.add_f64_values(values.clone());
-        for value in values.iter() {
-            let val: f64 = fake_rng.gen();
-            assert_eq!(val, *value);
-        }
-        let more_values = vec![0.5, 0.6, 0.7, 0.8];
-        fake_rng.add_f64_values(more_values.clone());
-        for value in more_values.iter() {
-            let val: f64 = fake_rng.gen();
-            assert_eq!(val, *value);
-        }
-        let val: f64 = fake_rng.gen();
-        assert_eq!(val, values[0]); // Wraps around
-        let val: u64 = fake_rng.gen();
-        assert_eq!(val, 0); // Default for u64
-        assert!(!fake_rng.gen::<bool>()); // Default for bool
-    }
-
-    #[test]
-    fn fake_add_values_u64() {
-        let mut fake_rng = FakeGenerator::new();
-        let values = (1..10).collect::<Vec<u64>>();
-        fake_rng.add_u64_values(values.clone());
-        for value in values.iter() {
-            let val: u64 = fake_rng.gen();
-            assert_eq!(val, *value);
-        }
-        let val: u64 = fake_rng.gen();
-        assert_eq!(val, values[0]); // Wraps around
-        let val: f64 = fake_rng.gen();
-        assert_eq!(val, 0.0); // Default for f64
-        assert!(!fake_rng.gen::<bool>()); // Default for bool
-    }
-
-    #[test]
-    fn fake_add_values_bool() {
-        let mut fake_rng = FakeGenerator::new();
-        let source = vec![true, false, true, false];
-        fake_rng.add_bool_values(source.clone());
-        for value in source.iter() {
-            let val: bool = fake_rng.gen();
-            assert_eq!(val, *value);
-        }
-        let val: bool = fake_rng.gen();
-        assert_eq!(val, source[0]); // Wraps around
-        let val: u64 = fake_rng.gen();
-        assert_eq!(val, 0); // Default for u64
-        let val: f64 = fake_rng.gen();
-        assert_eq!(val, 0.0); // Default for f64
-    }
-
-    #[test]
-    fn fake_rng_probabilities() {
-        let values = vec![0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 4.0, 5.0];
-        let mut fake_rng = FakeGenerator::from_f64_values(values.clone());
-        for _value in values.iter() {
-            assert!((0.0..=1.0).contains(&fake_rng.gen_probability()));
-        }
-    }
-
-    #[test]
-    fn fake_different_values() {
-        let mut fake_rng = FakeGenerator::from_f64_values(vec![0.1, 0.2, 0.3]);
-        let val1: f64 = fake_rng.gen();
-        let mut fake_rng2 = FakeGenerator::from_f64_values(vec![0.4, 0.5, 0.6]);
-        let val2: f64 = fake_rng2.gen();
-        assert_ne!(val1, val2);
+        assert_eq!(val1, 0); // Default value after reseed
     }
 
     #[test]
     fn fake_shuffle() {
-        let mut rng = FakeGenerator::new();
+        let mut rng = FakeGenerator::default();
         let mut vec = vec![1, 2, 3, 4, 5];
-        let original_vec = vec.clone();
         rng.shuffle(&mut vec);
-        assert_eq!(vec, original_vec);
+        assert_eq!(vec, vec![2, 3, 4, 5, 1]);
     }
 
     #[test]
     fn fake_sample_default() {
-        let mut rng = FakeGenerator::new();
+        let mut rng = FakeGenerator::default();
         let dist = WeightedIndex::new([1.0, 2.0, 3.0]).unwrap();
         assert_eq!(rng.sample(&dist), 0);
     }
 
     #[test]
     fn fake_sample() {
-        let mut rng = FakeGenerator::from_u64_values(vec![2, 0, 1]);
-        let dist = WeightedIndex::new([1.0, 2.0, 3.0]).unwrap();
-        assert_eq!(rng.sample(&dist), 2);
-        assert_eq!(rng.sample(&dist), 0);
+        let mut rng = FakeGenerator::default();
+        let dist = WeightedIndex::new([0.0, 3.0, 2.0, 1.0, 2.0]).unwrap();
+        assert_eq!(rng.sample(&dist), 1);
+        assert_eq!(rng.sample(&dist), 1);
         assert_eq!(rng.sample(&dist), 1);
     }
 }

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -97,8 +97,8 @@ mod tests {
 
     #[test]
     fn fake_rng_defaults() {
-        // Test new FakeGenerator defaults
-        let mut fake_rng = FakeGenerator::from_rng(FakeRng::default());
+        // Test FakeRng defaults
+        let mut fake_rng = RandomGenerator::from_rng(FakeRng::default());
         assert_eq!(fake_rng.seed(), 0);
         let val: u64 = fake_rng.random();
         assert_eq!(val, 0);
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn fake_generator_defaults() {
-        // Test new FakeGenerator defaults
+        // Test FakeGenerator defaults
         let mut fake_rng = FakeGenerator::default();
         assert_eq!(fake_rng.seed(), 0);
         let val: u64 = fake_rng.random();

--- a/phylo/src/random/fake_random.rs
+++ b/phylo/src/random/fake_random.rs
@@ -1,4 +1,4 @@
-use rand::{Error, RngCore, SeedableRng};
+use rand::{RngCore, SeedableRng};
 
 /// A fake random number generator for deterministic testing.
 /// Can return pre-configured values for unsigned (usize, u64, u32, u16, u8) and
@@ -26,11 +26,6 @@ impl RngCore for FakeRng {
                 *byte = bytes[i];
             }
         }
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
     }
 }
 
@@ -93,7 +88,7 @@ impl Default for FakeRng {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    use rand::distributions::WeightedIndex;
+    use rand::distr::weighted::WeightedIndex;
 
     use crate::random::{FakeGenerator, RandomGenerator};
 
@@ -129,29 +124,25 @@ mod tests {
     #[test]
     fn fake_rng_with_diff_types() {
         // Test FakeGenerator with different value types
-        let values = vec![5, 6, 7, 8, 9, 14, 15, 16, 17, 18];
+        let values = vec![5, 6, 7, 8, 9, 14, 15, 16];
         let mut fake_rng = RandomGenerator::from_rng(FakeRng::from_u64_values(values.clone()));
         assert_eq!(fake_rng.seed(), 0);
-        let val: usize = fake_rng.gen();
-        assert_eq!(val, values[0] as usize);
         let val: u64 = fake_rng.gen();
-        assert_eq!(val, values[1]);
+        assert_eq!(val, values[0]);
         let val: u32 = fake_rng.gen();
-        assert_eq!(val, values[2] as u32);
+        assert_eq!(val, values[1] as u32);
         let val: u16 = fake_rng.gen();
-        assert_eq!(val, values[3] as u16);
+        assert_eq!(val, values[2] as u16);
         let val: u8 = fake_rng.gen();
-        assert_eq!(val, values[4] as u8);
-        let val: isize = fake_rng.gen();
-        assert_eq!(val, values[5] as isize);
+        assert_eq!(val, values[3] as u8);
         let val: i64 = fake_rng.gen();
-        assert_eq!(val, values[6] as i64);
+        assert_eq!(val, values[4] as i64);
         let val: i32 = fake_rng.gen();
-        assert_eq!(val, values[7] as i32);
+        assert_eq!(val, values[5] as i32);
         let val: i16 = fake_rng.gen();
-        assert_eq!(val, values[8] as i16);
+        assert_eq!(val, values[6] as i16);
         let val: i8 = fake_rng.gen();
-        assert_eq!(val, values[9] as i8);
+        assert_eq!(val, values[7] as i8);
         let val: f64 = fake_rng.gen();
         assert_eq!(val, 0.0); // Default for f64
         let val: f32 = fake_rng.gen();
@@ -198,7 +189,7 @@ mod tests {
         let mut rng = FakeGenerator::default();
         let mut vec = vec![1, 2, 3, 4, 5];
         rng.shuffle(&mut vec);
-        assert_eq!(vec, vec![2, 3, 4, 5, 1]);
+        assert_eq!(vec, vec![5, 1, 2, 3, 4]);
     }
 
     #[test]

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use ntimestamp::Timestamp;
 use rand::distributions::uniform::{SampleRange, SampleUniform};
 use rand::distributions::{Distribution, Standard};
@@ -16,25 +14,25 @@ pub trait RandomSource {
     fn seed(&self) -> u64;
 
     /// Generate a random value of type T.
-    fn gen<T>(&self) -> T
+    fn gen<T>(&mut self) -> T
     where
         T: 'static,
         Standard: Distribution<T>;
 
     /// Generate a random bool with probability p.
-    fn gen_bool(&self, p: f64) -> bool;
+    fn gen_bool(&mut self, p: f64) -> bool;
 
     /// Generate a random uniform probability in the range [0.0, 1.0).
-    fn gen_probability(&self) -> f64;
+    fn gen_probability(&mut self) -> f64;
 
     /// Shuffle a slice in place.
-    fn shuffle<T>(&self, slice: &mut [T]);
+    fn shuffle<T>(&mut self, slice: &mut [T]);
 
     /// Reseed the RNG with a new seed.
-    fn reseed(&self, seed: u64);
+    fn reseed(&mut self, seed: u64);
 
     /// Sample from a weighted distribution.
-    fn sample<D, T>(&self, dist: &D) -> T
+    fn sample<D, T>(&mut self, dist: &D) -> T
     where
         T: 'static,
         D: Distribution<T>;
@@ -68,7 +66,7 @@ pub struct RandomGenerator<R>
 where
     R: Rng + SeedableRng + Send,
 {
-    r: Mutex<SeededRng<R>>,
+    r: SeededRng<R>,
 }
 
 impl<R> RandomGenerator<R>
@@ -78,10 +76,10 @@ where
     /// Create a new RandomGenerator with the given seed.
     pub fn new(seed: u64) -> Self {
         Self {
-            r: Mutex::new(SeededRng {
+            r: SeededRng {
                 seed,
                 rng: R::seed_from_u64(seed),
-            }),
+            },
         }
     }
 }
@@ -106,55 +104,45 @@ where
 {
     /// Get the current seed of the RNG.
     fn seed(&self) -> u64 {
-        let rng = self.r.lock().unwrap();
-        rng.seed
+        self.r.seed
     }
 
     /// Generate a random value of type T.
-    fn gen<T>(&self) -> T
+    fn gen<T>(&mut self) -> T
     where
         T: 'static,
         Standard: Distribution<T>,
     {
-        let mut r = self.r.lock().unwrap();
-        r.rng.gen::<T>()
+        self.r.rng.gen::<T>()
     }
 
     /// Generate a random bool with probability p.
-    fn gen_bool(&self, p: f64) -> bool {
-        let mut r = self.r.lock().unwrap();
-        r.rng.gen_bool(p)
+    fn gen_bool(&mut self, p: f64) -> bool {
+        self.r.rng.gen_bool(p)
     }
 
     /// Generate a random uniform probability in the range [0.0, 1.0).
-    fn gen_probability(&self) -> f64 {
-        let mut r = self.r.lock().unwrap();
-        r.rng.gen_range(0.0..1.0)
+    fn gen_probability(&mut self) -> f64 {
+        self.r.rng.gen_range(0.0..1.0)
     }
 
     /// Shuffle a slice in place.
-    fn shuffle<T>(&self, slice: &mut [T]) {
-        let mut r = self.r.lock().unwrap();
-        slice.shuffle(&mut r.rng);
+    fn shuffle<T>(&mut self, slice: &mut [T]) {
+        slice.shuffle(&mut self.r.rng);
     }
 
     /// Reseed the RNG with a new seed.
-    fn reseed(&self, seed: u64) {
-        let mut r = self.r.lock().unwrap();
-        *r = SeededRng {
-            seed,
-            rng: R::seed_from_u64(seed),
-        };
+    fn reseed(&mut self, seed: u64) {
+        *self = Self::new(seed);
     }
 
     /// Sample from a weighted distribution.
-    fn sample<D, T>(&self, dist: &D) -> T
+    fn sample<D, T>(&mut self, dist: &D) -> T
     where
         T: 'static,
         D: Distribution<T>,
     {
-        let mut r = self.r.lock().unwrap();
-        r.rng.sample(dist)
+        self.r.rng.sample(dist)
     }
 }
 
@@ -163,13 +151,12 @@ where
     R: Rng + SeedableRng + Send,
 {
     /// Generate a random value in the specified range.
-    pub fn gen_range<T, Range>(&self, range: Range) -> T
+    pub fn gen_range<T, Range>(&mut self, range: Range) -> T
     where
         T: 'static + SampleUniform,
         Range: SampleRange<T>,
     {
-        let mut r = self.r.lock().unwrap();
-        r.rng.gen_range(range)
+        self.r.rng.gen_range(range)
     }
 }
 
@@ -184,12 +171,12 @@ mod tests {
     #[test]
     fn rng_reproducibility() {
         // Test that creating new instances with the same seed produces the same sequence
-        let rng1 = DefaultGenerator::new(42);
+        let mut rng1 = DefaultGenerator::new(42);
         assert_eq!(rng1.seed(), 42);
         let val1: f64 = rng1.gen();
         let val2: u32 = rng1.gen();
 
-        let rng2 = DefaultGenerator::new(42);
+        let mut rng2 = DefaultGenerator::new(42);
         assert_eq!(rng2.seed(), 42);
         let val1_repeat: f64 = rng2.gen();
         let val2_repeat: u32 = rng2.gen();
@@ -202,7 +189,7 @@ mod tests {
     fn rng_different_types() {
         // Test that most common types can be generated from the same RNG instance and the
         // generator does not panic.
-        let rng = DefaultGenerator::new(42);
+        let mut rng = DefaultGenerator::new(42);
         assert_eq!(rng.seed(), 42);
         let _val: usize = rng.gen();
         let _val: u64 = rng.gen();
@@ -226,7 +213,7 @@ mod tests {
     #[test]
     fn reseed() {
         // Test that reseeding to the same value produces the same sample
-        let rng = DefaultGenerator::new(42);
+        let mut rng = DefaultGenerator::new(42);
         assert_eq!(rng.seed(), 42);
         let val1: f64 = rng.gen();
 
@@ -239,7 +226,7 @@ mod tests {
 
     #[test]
     fn rng_functions() {
-        let rng = DefaultGenerator::new(123);
+        let mut rng = DefaultGenerator::new(123);
         assert_eq!(rng.seed(), 123);
         let _random_f64: f64 = rng.gen::<f64>();
         let _random_probability = rng.gen_probability();
@@ -249,7 +236,7 @@ mod tests {
 
     #[test]
     fn rng_range() {
-        let rng = DefaultGenerator::new(123);
+        let mut rng = DefaultGenerator::new(123);
         assert_eq!(rng.seed(), 123);
         for _ in 0..10 {
             let val: u32 = rng.gen_range(1..100);
@@ -261,7 +248,7 @@ mod tests {
     fn different_seeds_produce_different_values() {
         // This is not guaranteed to produce different values because there are no guarantees on the Rng
         // implementation, but it is extremely unlikely that it will fail.
-        let rng = DefaultGenerator::new(1);
+        let mut rng = DefaultGenerator::new(1);
         assert_eq!(rng.seed(), 1);
         let val1: f64 = rng.gen();
         rng.reseed(2);
@@ -275,11 +262,11 @@ mod tests {
         // DefaultGenerator uses the current timestamp as a seed, so different instances should have different seeds
         // per definition of ntimestamp, but not guaranteed to produce different values, as in the previous test.
         let timestamp = Timestamp::now().as_u64();
-        let rng = DefaultGenerator::default();
+        let mut rng = DefaultGenerator::default();
         assert!(rng.seed() > timestamp);
         let val1: usize = rng.gen();
         let val2: f64 = rng.gen();
-        let rng2 = DefaultGenerator::default();
+        let mut rng2 = DefaultGenerator::default();
         assert!(rng2.seed() > rng.seed());
         assert!(rng2.seed() > timestamp);
         let val1_repeat: usize = rng2.gen();
@@ -290,7 +277,7 @@ mod tests {
 
     #[test]
     fn shuffle() {
-        let rng = DefaultGenerator::new(42);
+        let mut rng = DefaultGenerator::new(42);
         assert_eq!(rng.seed(), 42);
         let mut vec = vec![1, 2, 3, 4, 5];
         let original_vec = vec.clone();
@@ -302,7 +289,7 @@ mod tests {
 
     #[test]
     fn sample_weighted_index() {
-        let rng = DefaultGenerator::new(42);
+        let mut rng = DefaultGenerator::new(42);
         assert_eq!(rng.seed(), 42);
         let dist = WeightedIndex::new([1.0, 2.0, 3.0]).unwrap();
         let sample = rng.sample(&dist);

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -8,44 +8,6 @@ use rand::{Rng, SeedableRng};
 pub mod fake_random;
 pub use fake_random::*;
 
-/// Trait for random number generation
-pub trait RandomSource {
-    /// Get the current seed of the RNG.
-    fn seed(&self) -> u64;
-
-    /// Generate a random value of type T.
-    fn gen<T>(&mut self) -> T
-    where
-        T: 'static,
-        Standard: Distribution<T>;
-
-    /// Generate a random bool with probability p.
-    fn gen_bool(&mut self, p: f64) -> bool;
-
-    /// Generate a random uniform probability in the range [0.0, 1.0).
-    fn gen_probability(&mut self) -> f64;
-
-    /// Shuffle a slice in place.
-    fn shuffle<T>(&mut self, slice: &mut [T]);
-
-    /// Reseed the RNG with a new seed.
-    fn reseed(&mut self, seed: u64);
-
-    /// Sample from a weighted distribution.
-    fn sample<D, T>(&mut self, dist: &D) -> T
-    where
-        T: 'static,
-        D: Distribution<T>;
-}
-
-pub struct SeededRng<R>
-where
-    R: Rng + SeedableRng + Send,
-{
-    pub seed: u64,
-    pub rng: R,
-}
-
 /// A generic random number generator wrapper that can work with different RNGs.
 ///
 /// This provides a reusable interface for different RNG backends (not thread-safe per se).
@@ -56,32 +18,18 @@ where
 /// ```rust
 /// use rand::rngs::StdRng;
 ///
-/// use phylo::random::{RandomGenerator, RandomSource};
+/// use phylo::random::RandomGenerator;
 ///
 /// // Create a custom RNG instance
-/// let custom_rng: RandomGenerator<StdRng> = RandomGenerator::new(123);
+/// let mut custom_rng: RandomGenerator<StdRng> = RandomGenerator::new(123);
 /// let custom_value: f64 = custom_rng.gen();
 /// ```
 pub struct RandomGenerator<R>
 where
     R: Rng + SeedableRng + Send,
 {
-    r: SeededRng<R>,
-}
-
-impl<R> RandomGenerator<R>
-where
-    R: Rng + SeedableRng + Send,
-{
-    /// Create a new RandomGenerator with the given seed.
-    pub fn new(seed: u64) -> Self {
-        Self {
-            r: SeededRng {
-                seed,
-                rng: R::seed_from_u64(seed),
-            },
-        }
-    }
+    pub seed: u64,
+    pub rng: R,
 }
 
 /// Type alias for the default RNG implementation.
@@ -98,51 +46,15 @@ impl Default for DefaultGenerator {
     }
 }
 
-impl<R> RandomSource for RandomGenerator<R>
-where
-    R: Rng + SeedableRng + Send,
-{
-    /// Get the current seed of the RNG.
-    fn seed(&self) -> u64 {
-        self.r.seed
-    }
+/// Type alias for a Fake RNG implementation for testing purposes.
+#[cfg(test)]
+pub type FakeGenerator = RandomGenerator<FakeRng>;
 
-    /// Generate a random value of type T.
-    fn gen<T>(&mut self) -> T
-    where
-        T: 'static,
-        Standard: Distribution<T>,
-    {
-        self.r.rng.gen::<T>()
-    }
-
-    /// Generate a random bool with probability p.
-    fn gen_bool(&mut self, p: f64) -> bool {
-        self.r.rng.gen_bool(p)
-    }
-
-    /// Generate a random uniform probability in the range [0.0, 1.0).
-    fn gen_probability(&mut self) -> f64 {
-        self.r.rng.gen_range(0.0..1.0)
-    }
-
-    /// Shuffle a slice in place.
-    fn shuffle<T>(&mut self, slice: &mut [T]) {
-        slice.shuffle(&mut self.r.rng);
-    }
-
-    /// Reseed the RNG with a new seed.
-    fn reseed(&mut self, seed: u64) {
-        *self = Self::new(seed);
-    }
-
-    /// Sample from a weighted distribution.
-    fn sample<D, T>(&mut self, dist: &D) -> T
-    where
-        T: 'static,
-        D: Distribution<T>,
-    {
-        self.r.rng.sample(dist)
+#[cfg(test)]
+impl Default for FakeGenerator {
+    fn default() -> Self {
+        let seed = 0;
+        Self::new(seed)
     }
 }
 
@@ -150,13 +62,65 @@ impl<R> RandomGenerator<R>
 where
     R: Rng + SeedableRng + Send,
 {
+    /// Create a new RandomGenerator with the given seed.
+    pub fn new(seed: u64) -> Self {
+        Self {
+            seed,
+            rng: R::seed_from_u64(seed),
+        }
+    }
+
+    #[cfg(test)]
+    /// Create a new RandomGenerator from a given RNG instance.
+    pub(crate) fn from_rng(rng: R) -> Self {
+        Self { seed: 0, rng }
+    }
+
+    /// Get the current seed of the RNG.
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// Generate a random value of type T.
+    pub fn gen<T>(&mut self) -> T
+    where
+        T: 'static,
+        Standard: Distribution<T>,
+    {
+        self.rng.gen()
+    }
+
+    /// Generate a random bool with probability p.
+    pub fn gen_bool(&mut self, p: f64) -> bool {
+        self.rng.gen_bool(p)
+    }
+
+    /// Shuffle a slice in place.
+    pub fn shuffle<T>(&mut self, slice: &mut [T]) {
+        slice.shuffle(&mut self.rng);
+    }
+
+    /// Reseed the RNG with a new seed.
+    pub fn reseed(&mut self, seed: u64) {
+        *self = Self::new(seed);
+    }
+
+    /// Sample from a weighted distribution.
+    pub fn sample<D, T>(&mut self, dist: &D) -> T
+    where
+        T: 'static,
+        D: Distribution<T>,
+    {
+        self.rng.sample(dist)
+    }
+
     /// Generate a random value in the specified range.
     pub fn gen_range<T, Range>(&mut self, range: Range) -> T
     where
         T: 'static + SampleUniform,
         Range: SampleRange<T>,
     {
-        self.r.rng.gen_range(range)
+        self.rng.gen_range(range)
     }
 }
 
@@ -228,10 +192,11 @@ mod tests {
     fn rng_functions() {
         let mut rng = DefaultGenerator::new(123);
         assert_eq!(rng.seed(), 123);
-        let _random_f64: f64 = rng.gen::<f64>();
-        let _random_probability = rng.gen_probability();
+        assert!((0.0..1.0).contains(&rng.gen::<f64>()));
+        assert!((0.0..10.0).contains(&rng.gen_range(0.0..10.0)));
+        assert!((1..100).contains(&rng.gen_range(1..100)));
+
         let _random_bool = rng.gen_bool(0.5);
-        assert!((0.0..1.0).contains(&rng.gen_probability()));
     }
 
     #[test]

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -34,6 +34,8 @@ where
 
 /// Type alias for the default RNG implementation which uses ChaCha8Rng which is platform-independent.
 /// Note: ChaCha8Rng is not the most secure RNG, but is fast and suitable for most phylogenetic applications.
+/// Note: This implementation is not thread-reproducible, e.g. if used in multiple threads, the sequences
+/// generated may differ between runs. Users must handle this accordingly to ensure reproducibility if needed.
 pub type DefaultGenerator = RandomGenerator<ChaCha8Rng>;
 
 impl Default for DefaultGenerator {

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -3,7 +3,7 @@ use rand::distr::uniform::{SampleRange, SampleUniform};
 use rand::distr::{Distribution, StandardUniform};
 use rand::prelude::SliceRandom;
 use rand::{Rng, SeedableRng};
-use rand_chacha::ChaCha8Rng;
+use rand_pcg::Pcg32;
 
 pub mod fake_random;
 pub use fake_random::*;
@@ -33,11 +33,11 @@ where
     pub rng: R,
 }
 
-/// Type alias for the default RNG implementation which uses ChaCha8Rng which is platform-independent.
-/// Note: ChaCha8Rng is not the most secure RNG, but is fast and suitable for most phylogenetic applications.
+/// Type alias for the default RNG implementation which uses Pcg32 which is platform-independent.
+/// Note: Pcg32 is not the most secure RNG, but is fast and suitable for most phylogenetic applications.
 /// Note: This implementation is not thread-reproducible, e.g. if used in multiple threads, the sequences
 /// generated may differ between runs. Users must handle this accordingly to ensure reproducibility if needed.
-pub type DefaultGenerator = RandomGenerator<ChaCha8Rng>;
+pub type DefaultGenerator = RandomGenerator<Pcg32>;
 
 impl Default for DefaultGenerator {
     fn default() -> Self {

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -47,10 +47,8 @@ impl Default for DefaultGenerator {
 }
 
 /// Type alias for a Fake RNG implementation for testing purposes.
-#[cfg(test)]
 pub type FakeGenerator = RandomGenerator<FakeRng>;
 
-#[cfg(test)]
 impl Default for FakeGenerator {
     fn default() -> Self {
         let seed = 0;

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -2,8 +2,8 @@ use ntimestamp::Timestamp;
 use rand::distr::uniform::{SampleRange, SampleUniform};
 use rand::distr::{Distribution, StandardUniform};
 use rand::prelude::SliceRandom;
-use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 
 pub mod fake_random;
 pub use fake_random::*;
@@ -32,12 +32,9 @@ where
     pub rng: R,
 }
 
-/// Type alias for the default RNG implementation.
-/// Currently uses StdRng which is not platform-independent, and should be replaced with
-/// a platform-independent RNG.
-/// TODO: Replace with a platform-independent RNG implementation (at the moment `rand_pcg` and `rand_chacha`
-/// cause dependency clashes).
-pub type DefaultGenerator = RandomGenerator<StdRng>;
+/// Type alias for the default RNG implementation which uses ChaCha8Rng which is platform-independent.
+/// Note: ChaCha8Rng is not the most secure RNG, but is fast and suitable for most phylogenetic applications.
+pub type DefaultGenerator = RandomGenerator<ChaCha8Rng>;
 
 impl Default for DefaultGenerator {
     fn default() -> Self {

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -80,7 +80,7 @@ where
     }
 
     /// Generate a random value of type T.
-    pub fn gen<T>(&mut self) -> T
+    pub fn random<T>(&mut self) -> T
     where
         T: 'static,
         StandardUniform: Distribution<T>,
@@ -89,7 +89,7 @@ where
     }
 
     /// Generate a random bool with probability p.
-    pub fn gen_bool(&mut self, p: f64) -> bool {
+    pub fn random_bool(&mut self, p: f64) -> bool {
         self.rng.random_bool(p)
     }
 
@@ -113,7 +113,7 @@ where
     }
 
     /// Generate a random value in the specified range.
-    pub fn gen_range<T, Range>(&mut self, range: Range) -> T
+    pub fn random_range<T, Range>(&mut self, range: Range) -> T
     where
         T: 'static + SampleUniform,
         Range: SampleRange<T>,
@@ -135,13 +135,13 @@ mod tests {
         // Test that creating new instances with the same seed produces the same sequence
         let mut rng1 = DefaultGenerator::new(42);
         assert_eq!(rng1.seed(), 42);
-        let val1: f64 = rng1.gen();
-        let val2: u32 = rng1.gen();
+        let val1: f64 = rng1.random();
+        let val2: u32 = rng1.random();
 
         let mut rng2 = DefaultGenerator::new(42);
         assert_eq!(rng2.seed(), 42);
-        let val1_repeat: f64 = rng2.gen();
-        let val2_repeat: u32 = rng2.gen();
+        let val1_repeat: f64 = rng2.random();
+        let val2_repeat: u32 = rng2.random();
 
         assert_eq!(val1, val1_repeat);
         assert_eq!(val2, val2_repeat);
@@ -153,20 +153,20 @@ mod tests {
         // generator does not panic.
         let mut rng = DefaultGenerator::new(42);
         assert_eq!(rng.seed(), 42);
-        let _val: u64 = rng.gen();
-        let _val: u32 = rng.gen();
-        let _val: u16 = rng.gen();
-        let _val: u8 = rng.gen();
-        let _val: i128 = rng.gen();
-        let _val: i64 = rng.gen();
-        let _val: i32 = rng.gen();
-        let _val: i16 = rng.gen();
-        let _val: i8 = rng.gen();
-        let _val: char = rng.gen();
-        let _val: bool = rng.gen();
-        let val: f64 = rng.gen();
+        let _val: u64 = rng.random();
+        let _val: u32 = rng.random();
+        let _val: u16 = rng.random();
+        let _val: u8 = rng.random();
+        let _val: i128 = rng.random();
+        let _val: i64 = rng.random();
+        let _val: i32 = rng.random();
+        let _val: i16 = rng.random();
+        let _val: i8 = rng.random();
+        let _val: char = rng.random();
+        let _val: bool = rng.random();
+        let val: f64 = rng.random();
         assert!(val.is_finite() && !val.is_nan());
-        let val: f32 = rng.gen();
+        let val: f32 = rng.random();
         assert!(val.is_finite() && !val.is_nan());
     }
 
@@ -175,11 +175,11 @@ mod tests {
         // Test that reseeding to the same value produces the same sample
         let mut rng = DefaultGenerator::new(42);
         assert_eq!(rng.seed(), 42);
-        let val1: f64 = rng.gen();
+        let val1: f64 = rng.random();
 
         rng.reseed(42);
         assert_eq!(rng.seed(), 42);
-        let val1_repeat: f64 = rng.gen();
+        let val1_repeat: f64 = rng.random();
 
         assert_eq!(val1, val1_repeat);
     }
@@ -188,11 +188,11 @@ mod tests {
     fn rng_functions() {
         let mut rng = DefaultGenerator::new(123);
         assert_eq!(rng.seed(), 123);
-        assert!((0.0..1.0).contains(&rng.gen::<f64>()));
-        assert!((0.0..10.0).contains(&rng.gen_range(0.0..10.0)));
-        assert!((1..100).contains(&rng.gen_range(1..100)));
+        assert!((0.0..1.0).contains(&rng.random::<f64>()));
+        assert!((0.0..10.0).contains(&rng.random_range(0.0..10.0)));
+        assert!((1..100).contains(&rng.random_range(1..100)));
 
-        let _random_bool = rng.gen_bool(0.5);
+        let _random_bool = rng.random_bool(0.5);
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
         let mut rng = DefaultGenerator::new(123);
         assert_eq!(rng.seed(), 123);
         for _ in 0..10 {
-            let val: u32 = rng.gen_range(1..100);
+            let val: u32 = rng.random_range(1..100);
             assert!((1..100).contains(&val));
         }
     }
@@ -211,10 +211,10 @@ mod tests {
         // implementation, but it is extremely unlikely that it will fail.
         let mut rng = DefaultGenerator::new(1);
         assert_eq!(rng.seed(), 1);
-        let val1: f64 = rng.gen();
+        let val1: f64 = rng.random();
         rng.reseed(2);
         assert_eq!(rng.seed(), 2);
-        let val1_repeat: f64 = rng.gen();
+        let val1_repeat: f64 = rng.random();
         assert_ne!(val1, val1_repeat);
     }
 
@@ -225,13 +225,13 @@ mod tests {
         let timestamp = Timestamp::now().as_u64();
         let mut rng = DefaultGenerator::default();
         assert!(rng.seed() > timestamp);
-        let val1: u64 = rng.gen();
-        let val2: f64 = rng.gen();
+        let val1: u64 = rng.random();
+        let val2: f64 = rng.random();
         let mut rng2 = DefaultGenerator::default();
         assert!(rng2.seed() > rng.seed());
         assert!(rng2.seed() > timestamp);
-        let val1_repeat: u64 = rng2.gen();
-        let val2_repeat: f64 = rng2.gen();
+        let val1_repeat: u64 = rng2.random();
+        let val2_repeat: f64 = rng2.random();
         assert_ne!(val1, val1_repeat);
         assert_ne!(val2, val2_repeat);
     }

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -24,6 +24,7 @@ pub use fake_random::*;
 /// let mut custom_rng: RandomGenerator<StdRng> = RandomGenerator::new(123);
 /// let custom_value: f64 = custom_rng.random();
 /// ```
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RandomGenerator<R>
 where
     R: Rng + SeedableRng + Send,

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -10,8 +10,11 @@ pub use fake_random::*;
 
 /// A generic random number generator wrapper that can work with different RNGs.
 ///
-/// This provides a reusable interface for different RNG backends (not thread-safe per se).
-/// The RNG must implement `Rng + SeedableRng + Send`.
+/// This provides a reusable interface for different RNG backends, which must implement `Rng + SeedableRng`.
+/// Note: This implementation is not thread-reproducible, i.e. if used in multiple threads, the sequences
+/// generated may differ between runs. For phylogenetic analysis reproducibility both sequential and parallel
+/// runs should produce the same results when using the same seed.
+/// Users must handle this accordingly to ensure reproducibility if needed.
 ///
 /// # Examples
 ///
@@ -35,8 +38,6 @@ where
 
 /// Type alias for the default RNG implementation which uses Pcg32 which is platform-independent.
 /// Note: Pcg32 is not the most secure RNG, but is fast and suitable for most phylogenetic applications.
-/// Note: This implementation is not thread-reproducible, e.g. if used in multiple threads, the sequences
-/// generated may differ between runs. Users must handle this accordingly to ensure reproducibility if needed.
 pub type DefaultGenerator = RandomGenerator<Pcg32>;
 
 impl Default for DefaultGenerator {

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -48,7 +48,7 @@ where
 
 /// A generic random number generator wrapper that can work with different RNGs.
 ///
-/// This provides a thread-safe, reusable interface for different RNG backends.
+/// This provides a reusable interface for different RNG backends (not thread-safe per se).
 /// The RNG must implement `Rng + SeedableRng + Send`.
 ///
 /// # Examples

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -1,6 +1,6 @@
 use ntimestamp::Timestamp;
-use rand::distributions::uniform::{SampleRange, SampleUniform};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::uniform::{SampleRange, SampleUniform};
+use rand::distr::{Distribution, StandardUniform};
 use rand::prelude::SliceRandom;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -83,14 +83,14 @@ where
     pub fn gen<T>(&mut self) -> T
     where
         T: 'static,
-        Standard: Distribution<T>,
+        StandardUniform: Distribution<T>,
     {
-        self.rng.gen()
+        self.rng.random()
     }
 
     /// Generate a random bool with probability p.
     pub fn gen_bool(&mut self, p: f64) -> bool {
-        self.rng.gen_bool(p)
+        self.rng.random_bool(p)
     }
 
     /// Shuffle a slice in place.
@@ -118,7 +118,7 @@ where
         T: 'static + SampleUniform,
         Range: SampleRange<T>,
     {
-        self.rng.gen_range(range)
+        self.rng.random_range(range)
     }
 }
 
@@ -126,7 +126,7 @@ where
 #[cfg(test)]
 mod tests {
     use itertools::repeat_n;
-    use rand::distributions::WeightedIndex;
+    use rand::distr::weighted::WeightedIndex;
 
     use super::*;
 
@@ -153,12 +153,10 @@ mod tests {
         // generator does not panic.
         let mut rng = DefaultGenerator::new(42);
         assert_eq!(rng.seed(), 42);
-        let _val: usize = rng.gen();
         let _val: u64 = rng.gen();
         let _val: u32 = rng.gen();
         let _val: u16 = rng.gen();
         let _val: u8 = rng.gen();
-        let _val: isize = rng.gen();
         let _val: i128 = rng.gen();
         let _val: i64 = rng.gen();
         let _val: i32 = rng.gen();
@@ -227,12 +225,12 @@ mod tests {
         let timestamp = Timestamp::now().as_u64();
         let mut rng = DefaultGenerator::default();
         assert!(rng.seed() > timestamp);
-        let val1: usize = rng.gen();
+        let val1: u64 = rng.gen();
         let val2: f64 = rng.gen();
         let mut rng2 = DefaultGenerator::default();
         assert!(rng2.seed() > rng.seed());
         assert!(rng2.seed() > timestamp);
-        let val1_repeat: usize = rng2.gen();
+        let val1_repeat: u64 = rng2.gen();
         let val2_repeat: f64 = rng2.gen();
         assert_ne!(val1, val1_repeat);
         assert_ne!(val2, val2_repeat);

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -22,7 +22,7 @@ pub use fake_random::*;
 ///
 /// // Create a custom RNG instance
 /// let mut custom_rng: RandomGenerator<StdRng> = RandomGenerator::new(123);
-/// let custom_value: f64 = custom_rng.gen();
+/// let custom_value: f64 = custom_rng.random();
 /// ```
 pub struct RandomGenerator<R>
 where

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -81,7 +81,6 @@ where
     /// Generate a random value of type T.
     pub fn random<T>(&mut self) -> T
     where
-        T: 'static,
         StandardUniform: Distribution<T>,
     {
         self.rng.random()
@@ -105,7 +104,6 @@ where
     /// Sample from a weighted distribution.
     pub fn sample<D, T>(&mut self, dist: &D) -> T
     where
-        T: 'static,
         D: Distribution<T>,
     {
         self.rng.sample(dist)
@@ -114,7 +112,7 @@ where
     /// Generate a random value in the specified range.
     pub fn random_range<T, Range>(&mut self, range: Range) -> T
     where
-        T: 'static + SampleUniform,
+        T: SampleUniform,
         Range: SampleRange<T>,
     {
         self.rng.random_range(range)

--- a/phylo/src/random/mod.rs
+++ b/phylo/src/random/mod.rs
@@ -27,7 +27,7 @@ pub use fake_random::*;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RandomGenerator<R>
 where
-    R: Rng + SeedableRng + Send,
+    R: Rng + SeedableRng,
 {
     pub seed: u64,
     pub rng: R,
@@ -58,7 +58,7 @@ impl Default for FakeGenerator {
 
 impl<R> RandomGenerator<R>
 where
-    R: Rng + SeedableRng + Send,
+    R: Rng + SeedableRng,
 {
     /// Create a new RandomGenerator with the given seed.
     pub fn new(seed: u64) -> Self {

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use approx::assert_relative_eq;
 use itertools::repeat_n;
 use nalgebra::dvector;
-use rand::Rng;
+use rand::{rng, Rng};
 
 use crate::alignment::{Alignment, Sequences, MSA};
 use crate::alphabets::{dna_alphabet, protein_alphabet, Alphabet, AMINOACIDS, GAP};
@@ -340,9 +340,9 @@ fn protein_correct_access_template<Q: QMatrix + QMatrixMaker>(epsilon: f64) {
     let model_2 = SubstModel::<Q>::new(&[], &[]);
     assert_relative_eq!(model_1.q(), model_2.q());
     for _ in 0..10 {
-        let mut rng = rand::thread_rng();
-        let query1 = AMINOACIDS[rng.gen_range(0..AMINOACIDS.len())];
-        let query2 = AMINOACIDS[rng.gen_range(0..AMINOACIDS.len())];
+        let mut rng = rng();
+        let query1 = AMINOACIDS[rng.random_range(0..AMINOACIDS.len())];
+        let query2 = AMINOACIDS[rng.random_range(0..AMINOACIDS.len())];
         model_1.rate(query1, query2);
     }
     assert_relative_eq!(model_1.freqs().sum(), 1.0, epsilon = epsilon);

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -419,7 +419,7 @@ where
             }
         }
     }
-    arg_min[(rng.gen_range(0..arg_min.len() as u64)) as usize]
+    arg_min[(rng.random_range(0..arg_min.len() as u64)) as usize]
 }
 
 fn build_nj_tree_from_matrix_w_rng<R>(

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -419,7 +419,7 @@ where
             }
         }
     }
-    arg_min[(rng.random_range(0..arg_min.len() as u64)) as usize]
+    arg_min[rng.random_range(0..arg_min.len())]
 }
 
 fn build_nj_tree_from_matrix_w_rng<R>(

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -399,7 +399,7 @@ pub fn percentiles_rounded(lengths: &[f64], categories: u32, rounding: &Rounding
 
 fn argmin_wo_diagonal_w_rng<R>(q: Mat, rng: &mut RandomGenerator<R>) -> (usize, usize)
 where
-    R: Rng + SeedableRng + Send,
+    R: Rng + SeedableRng,
 {
     debug_assert!(!q.is_empty(), "The input matrix must not be empty");
     debug_assert!(
@@ -428,7 +428,7 @@ fn build_nj_tree_from_matrix_w_rng<R>(
     rng: &mut RandomGenerator<R>,
 ) -> Result<Tree>
 where
-    R: Rng + SeedableRng + Send,
+    R: Rng + SeedableRng,
 {
     let n = nj_data.distances.ncols();
     let mut tree = Tree::new(sequences)?;
@@ -459,7 +459,7 @@ pub fn build_nj_tree(sequences: &Sequences) -> Result<Tree> {
 
 pub fn build_nj_tree_w_rng<R>(sequences: &Sequences, rng: &mut RandomGenerator<R>) -> Result<Tree>
 where
-    R: Rng + SeedableRng + Send,
+    R: Rng + SeedableRng,
 {
     let nj_data = compute_distance_matrix(sequences);
     build_nj_tree_from_matrix_w_rng(nj_data, sequences, rng)

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -6,10 +6,11 @@ use bio::alignment::distance::levenshtein;
 use fixedbitset::FixedBitSet;
 use inc_stats::Percentiles;
 use nalgebra::{max, DMatrix};
+use rand::{Rng, SeedableRng};
 
 use crate::alignment::Sequences;
 use crate::parsimony::Rounding;
-use crate::random::{DefaultGenerator, RandomSource};
+use crate::random::{DefaultGenerator, RandomGenerator};
 use crate::tree::{
     nj_matrices::{Mat, NJMat},
     NodeIdx::{Internal as Int, Leaf},
@@ -396,7 +397,10 @@ pub fn percentiles_rounded(lengths: &[f64], categories: u32, rounding: &Rounding
     values
 }
 
-fn argmin_wo_diagonal_w_rng(q: Mat, rng: &mut impl RandomSource) -> (usize, usize) {
+fn argmin_wo_diagonal_w_rng<R>(q: Mat, rng: &mut RandomGenerator<R>) -> (usize, usize)
+where
+    R: Rng + SeedableRng + Send,
+{
     debug_assert!(!q.is_empty(), "The input matrix must not be empty");
     debug_assert!(
         q.ncols() > 1 && q.nrows() > 1,
@@ -418,11 +422,14 @@ fn argmin_wo_diagonal_w_rng(q: Mat, rng: &mut impl RandomSource) -> (usize, usiz
     arg_min[rng.gen::<usize>() % arg_min.len()]
 }
 
-fn build_nj_tree_from_matrix_w_rng(
+fn build_nj_tree_from_matrix_w_rng<R>(
     mut nj_data: NJMat,
     sequences: &Sequences,
-    rng: &mut impl RandomSource,
-) -> Result<Tree> {
+    rng: &mut RandomGenerator<R>,
+) -> Result<Tree>
+where
+    R: Rng + SeedableRng + Send,
+{
     let n = nj_data.distances.ncols();
     let mut tree = Tree::new(sequences)?;
     let root_idx = usize::from(&tree.root);
@@ -450,7 +457,10 @@ pub fn build_nj_tree(sequences: &Sequences) -> Result<Tree> {
     build_nj_tree_from_matrix_w_rng(nj_data, sequences, &mut DefaultGenerator::default())
 }
 
-pub fn build_nj_tree_w_rng(sequences: &Sequences, rng: &mut impl RandomSource) -> Result<Tree> {
+pub fn build_nj_tree_w_rng<R>(sequences: &Sequences, rng: &mut RandomGenerator<R>) -> Result<Tree>
+where
+    R: Rng + SeedableRng + Send,
+{
     let nj_data = compute_distance_matrix(sequences);
     build_nj_tree_from_matrix_w_rng(nj_data, sequences, rng)
 }

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -396,7 +396,7 @@ pub fn percentiles_rounded(lengths: &[f64], categories: u32, rounding: &Rounding
     values
 }
 
-fn argmin_wo_diagonal_w_rng(q: Mat, rng: &impl RandomSource) -> (usize, usize) {
+fn argmin_wo_diagonal_w_rng(q: Mat, rng: &mut impl RandomSource) -> (usize, usize) {
     debug_assert!(!q.is_empty(), "The input matrix must not be empty");
     debug_assert!(
         q.ncols() > 1 && q.nrows() > 1,
@@ -421,7 +421,7 @@ fn argmin_wo_diagonal_w_rng(q: Mat, rng: &impl RandomSource) -> (usize, usize) {
 fn build_nj_tree_from_matrix_w_rng(
     mut nj_data: NJMat,
     sequences: &Sequences,
-    rng: &impl RandomSource,
+    rng: &mut impl RandomSource,
 ) -> Result<Tree> {
     let n = nj_data.distances.ncols();
     let mut tree = Tree::new(sequences)?;
@@ -447,10 +447,10 @@ fn build_nj_tree_from_matrix_w_rng(
 
 pub fn build_nj_tree(sequences: &Sequences) -> Result<Tree> {
     let nj_data = compute_distance_matrix(sequences);
-    build_nj_tree_from_matrix_w_rng(nj_data, sequences, &DefaultGenerator::default())
+    build_nj_tree_from_matrix_w_rng(nj_data, sequences, &mut DefaultGenerator::default())
 }
 
-pub fn build_nj_tree_w_rng(sequences: &Sequences, rng: &impl RandomSource) -> Result<Tree> {
+pub fn build_nj_tree_w_rng(sequences: &Sequences, rng: &mut impl RandomSource) -> Result<Tree> {
     let nj_data = compute_distance_matrix(sequences);
     build_nj_tree_from_matrix_w_rng(nj_data, sequences, rng)
 }

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -419,7 +419,7 @@ where
             }
         }
     }
-    arg_min[rng.gen::<usize>() % arg_min.len()]
+    arg_min[(rng.gen_range(0..arg_min.len() as u64)) as usize]
 }
 
 fn build_nj_tree_from_matrix_w_rng<R>(

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -7,7 +7,7 @@ use fixedbitset::FixedBitSet;
 use itertools::repeat_n;
 use nalgebra::{dmatrix, DMatrix};
 use pest::error::ErrorVariant;
-use rand::Rng;
+use rand::{rng, Rng};
 use rstest::rstest;
 
 use crate::alignment::Sequences;
@@ -665,9 +665,9 @@ fn compute_distance_matrix_far() {
 
 #[test]
 fn test_node_idx_from_usize() {
-    let r1 = rand::thread_rng().gen_range(1..100);
+    let r1 = rng().random_range(1..100);
     assert_eq!(usize::from(&L(r1)), r1);
-    let r2 = rand::thread_rng().gen_range(1..100);
+    let r2 = rng().random_range(1..100);
     assert_eq!(usize::from(&I(r2)), r2);
 }
 

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -164,7 +164,7 @@ fn nj_correct_web_example() {
     let nj_tree = build_nj_tree_from_matrix_w_rng(
         nj_distances,
         &sequences,
-        &FakeGenerator::from_u64_values(vec![0]),
+        &mut FakeGenerator::from_u64_values(vec![0]),
     )
     .unwrap();
     let nodes = vec![
@@ -183,7 +183,7 @@ fn nj_correct_web_example() {
 
 #[test]
 fn nj_correct() {
-    let fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
     let nj_distances = NJMat {
         idx: (0..5).map(NodeIdx::Leaf).collect(),
         distances: dmatrix![
@@ -200,7 +200,7 @@ fn nj_correct() {
         record!("D3", b""),
         record!("E4", b""),
     ]);
-    let nj_tree = build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &fake_rng).unwrap();
+    let nj_tree = build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &mut fake_rng).unwrap();
     let nodes = vec![
         Node::new_leaf(0, Some(I(5)), 2.0, "A0".to_string()),
         Node::new_leaf(1, Some(I(5)), 3.0, "B1".to_string()),
@@ -225,7 +225,7 @@ fn is_unique<T: std::cmp::Eq + std::hash::Hash>(vec: &[T]) -> bool {
 #[test]
 fn protein_nj_correct() {
     // NJ based on example sequences from "./data/sequences_protein1.fasta"
-    let fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
     let nj_distances = NJMat {
         idx: (0..4).map(NodeIdx::Leaf).collect(),
         distances: dmatrix![
@@ -240,7 +240,7 @@ fn protein_nj_correct() {
         record!("C2", b""),
         record!("D3", b""),
     ]);
-    let tree = build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &fake_rng).unwrap();
+    let tree = build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &mut fake_rng).unwrap();
     assert_eq!(tree.len(), 7);
     assert_eq!(tree.postorder.len(), 7);
     assert!(is_unique(&tree.postorder));
@@ -251,7 +251,7 @@ fn protein_nj_correct() {
 #[test]
 fn nj_correct_2() {
     // NJ based on example from https://www.tenderisthebyte.com/blog/2022/08/31/neighbor-joining-trees/#neighbor-joining-trees
-    let fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
     let nj_distances = NJMat {
         idx: (0..4).map(NodeIdx::Leaf).collect(),
         distances: dmatrix![
@@ -266,7 +266,7 @@ fn nj_correct_2() {
         record!("C", b""),
         record!("D", b""),
     ]);
-    let tree = build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &fake_rng).unwrap();
+    let tree = build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &mut fake_rng).unwrap();
     assert_eq!(tree.by_id("A").blen, 1.0);
     assert_eq!(tree.by_id("B").blen, 3.0);
     assert_eq!(tree.by_id("C").blen, 2.0);
@@ -283,7 +283,7 @@ fn nj_correct_2() {
 #[test]
 fn nj_correct_wiki_example() {
     // NJ based on example from https://en.wikipedia.org/wiki/Neighbor_joining
-    let fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
     let nj_distances = NJMat {
         idx: (0..5).map(NodeIdx::Leaf).collect(),
         distances: dmatrix![
@@ -300,7 +300,7 @@ fn nj_correct_wiki_example() {
         record!("d", b""),
         record!("e", b""),
     ]);
-    let tree = build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &fake_rng).unwrap();
+    let tree = build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &mut fake_rng).unwrap();
     assert_eq!(tree.by_id("a").blen, 2.0);
     assert_eq!(tree.by_id("b").blen, 3.0);
     assert_eq!(tree.by_id("c").blen, 4.0);
@@ -706,7 +706,7 @@ fn test_node_id_string() {
 
 #[test]
 fn test_node_idx_display() {
-    let rng = DefaultGenerator::default();
+    let mut rng = DefaultGenerator::default();
     let r1 = rng.gen_range(1..100);
     assert_eq!(format!("{}", L(r1)), format!("leaf node {}", r1));
     let r2 = rng.gen_range(1..100);
@@ -715,7 +715,7 @@ fn test_node_idx_display() {
 
 #[test]
 fn test_node_idx_debug() {
-    let rng = DefaultGenerator::default();
+    let mut rng = DefaultGenerator::default();
     let r1 = rng.gen_range(1..100);
     assert_eq!(format!("{:?}", L(r1)), format!("Leaf({})", r1));
     let r2 = rng.gen_range(1..100);
@@ -725,8 +725,8 @@ fn test_node_idx_debug() {
 #[test]
 #[should_panic]
 fn test_argmin_fail() {
-    let fake_rng = FakeGenerator::from_u64_values(vec![0]);
-    argmin_wo_diagonal_w_rng(DMatrix::<f64>::from_vec(1, 1, vec![0.0]), &fake_rng);
+    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    argmin_wo_diagonal_w_rng(DMatrix::<f64>::from_vec(1, 1, vec![0.0]), &mut fake_rng);
 }
 
 #[test]

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -12,7 +12,7 @@ use rand::Rng;
 use crate::alignment::Sequences;
 use crate::io::read_newick_from_file;
 use crate::parsimony::Rounding;
-use crate::random::{DefaultGenerator, FakeGenerator};
+use crate::random::FakeGenerator;
 use crate::tree::{
     argmin_wo_diagonal_w_rng, build_nj_tree_from_matrix_w_rng, compute_distance_matrix,
     nj_matrices::NJMat,
@@ -161,12 +161,9 @@ fn nj_correct_web_example() {
         record!("C2", b""),
         record!("D3", b""),
     ]);
-    let nj_tree = build_nj_tree_from_matrix_w_rng(
-        nj_distances,
-        &sequences,
-        &mut FakeGenerator::from_u64_values(vec![0]),
-    )
-    .unwrap();
+    let nj_tree =
+        build_nj_tree_from_matrix_w_rng(nj_distances, &sequences, &mut FakeGenerator::default())
+            .unwrap();
     let nodes = vec![
         Node::new_leaf(0, Some(I(4)), 1.0, "A0".to_string()),
         Node::new_leaf(1, Some(I(4)), 3.0, "B1".to_string()),
@@ -183,7 +180,7 @@ fn nj_correct_web_example() {
 
 #[test]
 fn nj_correct() {
-    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::default();
     let nj_distances = NJMat {
         idx: (0..5).map(NodeIdx::Leaf).collect(),
         distances: dmatrix![
@@ -225,7 +222,7 @@ fn is_unique<T: std::cmp::Eq + std::hash::Hash>(vec: &[T]) -> bool {
 #[test]
 fn protein_nj_correct() {
     // NJ based on example sequences from "./data/sequences_protein1.fasta"
-    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::default();
     let nj_distances = NJMat {
         idx: (0..4).map(NodeIdx::Leaf).collect(),
         distances: dmatrix![
@@ -251,7 +248,7 @@ fn protein_nj_correct() {
 #[test]
 fn nj_correct_2() {
     // NJ based on example from https://www.tenderisthebyte.com/blog/2022/08/31/neighbor-joining-trees/#neighbor-joining-trees
-    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::default();
     let nj_distances = NJMat {
         idx: (0..4).map(NodeIdx::Leaf).collect(),
         distances: dmatrix![
@@ -283,7 +280,7 @@ fn nj_correct_2() {
 #[test]
 fn nj_correct_wiki_example() {
     // NJ based on example from https://en.wikipedia.org/wiki/Neighbor_joining
-    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::default();
     let nj_distances = NJMat {
         idx: (0..5).map(NodeIdx::Leaf).collect(),
         distances: dmatrix![
@@ -725,7 +722,7 @@ fn test_node_idx_debug() {
 #[test]
 #[should_panic]
 fn test_argmin_fail() {
-    let mut fake_rng = FakeGenerator::from_u64_values(vec![0]);
+    let mut fake_rng = FakeGenerator::default();
     argmin_wo_diagonal_w_rng(DMatrix::<f64>::from_vec(1, 1, vec![0.0]), &mut fake_rng);
 }
 

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -8,6 +8,7 @@ use itertools::repeat_n;
 use nalgebra::{dmatrix, DMatrix};
 use pest::error::ErrorVariant;
 use rand::Rng;
+use rstest::rstest;
 
 use crate::alignment::Sequences;
 use crate::io::read_newick_from_file;
@@ -701,22 +702,24 @@ fn test_node_id_string() {
     }
 }
 
-#[test]
-fn test_node_idx_display() {
-    let mut rng = DefaultGenerator::default();
-    let r1 = rng.gen_range(1..100);
-    assert_eq!(format!("{}", L(r1)), format!("leaf node {}", r1));
-    let r2 = rng.gen_range(1..100);
-    assert_eq!(format!("{}", I(r2)), format!("internal node {}", r2));
+#[rstest]
+#[case(0)]
+#[case(1)]
+#[case(42)]
+#[case(99)]
+fn test_node_idx_display(#[case] idx: usize) {
+    assert_eq!(format!("{}", L(idx)), format!("leaf node {}", idx));
+    assert_eq!(format!("{}", I(idx)), format!("internal node {}", idx));
 }
 
-#[test]
-fn test_node_idx_debug() {
-    let mut rng = DefaultGenerator::default();
-    let r1 = rng.gen_range(1..100);
-    assert_eq!(format!("{:?}", L(r1)), format!("Leaf({})", r1));
-    let r2 = rng.gen_range(1..100);
-    assert_eq!(format!("{:?}", I(r2)), format!("Int({})", r2));
+#[rstest]
+#[case(0)]
+#[case(1)]
+#[case(42)]
+#[case(99)]
+fn test_node_idx_debug(#[case] idx: usize) {
+    assert_eq!(format!("{:?}", L(idx)), format!("Leaf({})", idx));
+    assert_eq!(format!("{:?}", I(idx)), format!("Int({})", idx));
 }
 
 #[test]


### PR DESCRIPTION
Addressing #90 to remove traits/structs that have similar names to objects existing in rand already, removing unnecessary Mutex'es and simplifying the random number generators in general.