### PR TITLE
Enhancement/alphabet refactor

### DIFF
--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -188,7 +188,7 @@ impl Alignment for MSA {
     /// # Ok(()) }
     ///
     fn alphabet(&self) -> &Alphabet {
-        &self.seqs.alphabet
+        self.seqs.alphabet
     }
 
     fn seqs(&self) -> &Sequences {
@@ -349,7 +349,7 @@ impl Display for MASA {
 
 impl Alignment for MASA {
     fn alphabet(&self) -> &Alphabet {
-        &self.leaf_seqs.alphabet
+        self.leaf_seqs.alphabet
     }
 
     fn seqs(&self) -> &Sequences {

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -182,9 +182,9 @@ impl Alignment for MSA {
     ///     record!("A0", Some("A0 sequence"), b"AAAA"),
     ///     record!("B1", Some("B1 sequence"), b"---A"),
     ///     record!("C2", Some("C2 sequence"), b"AA--"),
-    /// ], dna_alphabet());
+    /// ], Alphabet::dna());
     /// let msa = MSA::from_aligned(seqs, &tree)?;
-    /// assert_eq!(*msa.alphabet(), dna_alphabet());
+    /// assert_eq!(*msa.alphabet(), Alphabet::dna());
     /// # Ok(()) }
     ///
     fn alphabet(&self) -> &Alphabet {

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -172,9 +172,8 @@ impl Alignment for MSA {
     /// # Example
     /// ```
     /// # use bio::io::fasta::Record;
-    /// use phylo::alignment::{MSA, Alignment};
-    /// use phylo::alignment::Sequences;
-    /// use phylo::alphabets::dna_alphabet;
+    /// use phylo::alignment::{Alignment, MSA, Sequences};
+    /// use phylo::alphabets::Alphabet;
     /// use phylo::{record, tree};
     /// # fn main() -> std::result::Result<(), anyhow::Error> {
     /// let tree = tree!("(((A0:1.0,B1:1.0):1.0,C2:1.0):1.0);");
@@ -184,7 +183,7 @@ impl Alignment for MSA {
     ///     record!("C2", Some("C2 sequence"), b"AA--"),
     /// ], Alphabet::dna());
     /// let msa = MSA::from_aligned(seqs, &tree)?;
-    /// assert_eq!(*msa.alphabet(), Alphabet::dna());
+    /// assert_eq!(msa.alphabet(), Alphabet::dna());
     /// # Ok(()) }
     ///
     fn alphabet(&self) -> &Alphabet {

--- a/phylo/src/alignment/sequences.rs
+++ b/phylo/src/alignment/sequences.rs
@@ -12,7 +12,7 @@ use crate::{record, Result};
 pub struct Sequences {
     pub(crate) s: Vec<Record>,
     pub(crate) aligned: bool,
-    pub(crate) alphabet: Alphabet,
+    pub(crate) alphabet: &'static Alphabet,
 }
 
 impl PartialEq for Sequences {
@@ -40,26 +40,16 @@ impl Display for Sequences {
 }
 
 impl Sequences {
-    fn detect_alphabet(sequences: &[Record]) -> Alphabet {
-        let dna_alphabet = Alphabet::dna();
-        for record in sequences.iter() {
-            if !dna_alphabet.is_word(record.seq()) {
-                return Alphabet::protein();
-            }
-        }
-        dna_alphabet
-    }
-
     /// Creates a new Sequences object from a vector of bio::io::fasta::Record.
     /// The Sequences object is considered aligned if all sequences have the same length.
     pub fn new(s: Vec<Record>) -> Sequences {
-        let alphabet = Self::detect_alphabet(&s);
+        let alphabet = detect_alphabet(&s);
         Self::with_alphabet(s, alphabet)
     }
 
     /// Creates a new Sequences object from a vector of bio::io::fasta::Record and a provided alphabet.
     /// The Sequences object is considered aligned if all sequences have the same length.
-    pub fn with_alphabet(s: Vec<Record>, alphabet: Alphabet) -> Sequences {
+    pub fn with_alphabet(s: Vec<Record>, alphabet: &'static Alphabet) -> Sequences {
         let potential_msa_len = if s.is_empty() { 0 } else { s[0].seq().len() };
         // Sequences are aligned if all sequences are the same length
         let aligned = s.iter().skip(1).all(|r| r.seq().len() == potential_msa_len);
@@ -106,8 +96,8 @@ impl Sequences {
         }
     }
 
-    pub fn alphabet(&self) -> &Alphabet {
-        &self.alphabet
+    pub fn alphabet(&self) -> &'static Alphabet {
+        self.alphabet
     }
 
     /// Removes all gaps from the sequences and returns a new Sequences object.
@@ -128,7 +118,7 @@ impl Sequences {
         Sequences {
             s: seqs,
             aligned: false,
-            alphabet: *self.alphabet(),
+            alphabet: self.alphabet,
         }
     }
 
@@ -170,6 +160,16 @@ impl Sequences {
     }
 }
 
+fn detect_alphabet(sequences: &[Record]) -> &'static Alphabet {
+    let dna_alphabet = Alphabet::dna();
+    for record in sequences.iter() {
+        if !dna_alphabet.is_word(record.seq()) {
+            return Alphabet::protein();
+        }
+    }
+    dna_alphabet
+}
+
 #[cfg(test)]
 mod private_tests {
     use rstest::rstest;
@@ -184,7 +184,7 @@ mod private_tests {
     #[case::long("./data/sequences_long.fasta")]
     fn dna_type_test(#[case] input: &str) {
         let seqs = read_sequences(input).unwrap();
-        let alphabet = Sequences::detect_alphabet(&seqs);
+        let alphabet = detect_alphabet(&seqs);
         assert_eq!(alphabet, Alphabet::dna());
         assert!(format!("{alphabet}").contains("DNA"));
     }
@@ -194,7 +194,7 @@ mod private_tests {
     #[case("./data/sequences_protein2.fasta")]
     fn protein_type_test(#[case] input: &str) {
         let seqs = read_sequences(input).unwrap();
-        let alphabet = Sequences::detect_alphabet(&seqs);
+        let alphabet = detect_alphabet(&seqs);
         assert_eq!(alphabet, Alphabet::protein());
         assert!(format!("{alphabet}").contains("protein"));
     }

--- a/phylo/src/alignment/sequences.rs
+++ b/phylo/src/alignment/sequences.rs
@@ -186,7 +186,6 @@ mod private_tests {
         let seqs = read_sequences(input).unwrap();
         let alphabet = detect_alphabet(&seqs);
         assert_eq!(alphabet, Alphabet::dna());
-        assert!(format!("{alphabet}").contains("DNA"));
     }
 
     #[rstest]
@@ -196,7 +195,6 @@ mod private_tests {
         let seqs = read_sequences(input).unwrap();
         let alphabet = detect_alphabet(&seqs);
         assert_eq!(alphabet, Alphabet::protein());
-        assert!(format!("{alphabet}").contains("protein"));
     }
 
     #[test]

--- a/phylo/src/alignment/sequences.rs
+++ b/phylo/src/alignment/sequences.rs
@@ -5,7 +5,7 @@ use bio::io::fasta::Record;
 use bitvec::vec::BitVec;
 use hashbrown::HashSet;
 
-use crate::alphabets::{dna_alphabet, protein_alphabet, Alphabet, GAP};
+use crate::alphabets::{Alphabet, GAP};
 use crate::{record, Result};
 
 #[derive(Debug, Clone)]
@@ -41,10 +41,10 @@ impl Display for Sequences {
 
 impl Sequences {
     fn detect_alphabet(sequences: &[Record]) -> Alphabet {
-        let dna_alphabet = dna_alphabet();
+        let dna_alphabet = Alphabet::dna();
         for record in sequences.iter() {
             if !dna_alphabet.is_word(record.seq()) {
-                return protein_alphabet();
+                return Alphabet::protein();
             }
         }
         dna_alphabet
@@ -185,7 +185,7 @@ mod private_tests {
     fn dna_type_test(#[case] input: &str) {
         let seqs = read_sequences(input).unwrap();
         let alphabet = Sequences::detect_alphabet(&seqs);
-        assert_eq!(alphabet, dna_alphabet());
+        assert_eq!(alphabet, Alphabet::dna());
         assert!(format!("{alphabet}").contains("DNA"));
     }
 
@@ -195,7 +195,7 @@ mod private_tests {
     fn protein_type_test(#[case] input: &str) {
         let seqs = read_sequences(input).unwrap();
         let alphabet = Sequences::detect_alphabet(&seqs);
-        assert_eq!(alphabet, protein_alphabet());
+        assert_eq!(alphabet, Alphabet::protein());
         assert!(format!("{alphabet}").contains("protein"));
     }
 

--- a/phylo/src/alignment/tests.rs
+++ b/phylo/src/alignment/tests.rs
@@ -5,7 +5,7 @@ use crate::alignment::{
     Alignment, AncestralAlignment, InternalAlignments, PairwiseAlignment as PA, SeqMaps, Sequences,
     MASA, MSA,
 };
-use crate::alphabets::{dna_alphabet, protein_alphabet, AMINOACIDS, NUCLEOTIDES};
+use crate::alphabets::{Alphabet, AMINOACIDS, NUCLEOTIDES};
 use crate::io::read_sequences;
 use crate::phylo_info::PhyloInfo;
 use crate::tree::{
@@ -109,15 +109,15 @@ fn sequences_with_alphabet() {
         record!("E4", Some("E4 sequence"), b"-A-AAA"),
     ];
 
-    let dna_seqs = Sequences::with_alphabet(records.clone(), dna_alphabet());
+    let dna_seqs = Sequences::with_alphabet(records.clone(), Alphabet::dna());
     assert_eq!(dna_seqs.alphabet().symbols(), NUCLEOTIDES);
     assert_ne!(dna_seqs.alphabet().symbols(), AMINOACIDS);
-    assert_eq!(*dna_seqs.alphabet(), dna_alphabet());
+    assert_eq!(*dna_seqs.alphabet(), Alphabet::dna());
 
-    let protein_seqs = Sequences::with_alphabet(records.clone(), protein_alphabet());
+    let protein_seqs = Sequences::with_alphabet(records.clone(), Alphabet::protein());
     assert_eq!(protein_seqs.alphabet().symbols(), AMINOACIDS);
     assert_ne!(protein_seqs.alphabet().symbols(), NUCLEOTIDES);
-    assert_eq!(*protein_seqs.alphabet(), protein_alphabet());
+    assert_eq!(*protein_seqs.alphabet(), Alphabet::protein());
 }
 
 #[test]

--- a/phylo/src/alignment/tests.rs
+++ b/phylo/src/alignment/tests.rs
@@ -112,12 +112,12 @@ fn sequences_with_alphabet() {
     let dna_seqs = Sequences::with_alphabet(records.clone(), Alphabet::dna());
     assert_eq!(dna_seqs.alphabet().symbols(), NUCLEOTIDES);
     assert_ne!(dna_seqs.alphabet().symbols(), AMINOACIDS);
-    assert_eq!(*dna_seqs.alphabet(), Alphabet::dna());
+    assert_eq!(dna_seqs.alphabet(), Alphabet::dna());
 
     let protein_seqs = Sequences::with_alphabet(records.clone(), Alphabet::protein());
     assert_eq!(protein_seqs.alphabet().symbols(), AMINOACIDS);
     assert_ne!(protein_seqs.alphabet().symbols(), NUCLEOTIDES);
-    assert_eq!(*protein_seqs.alphabet(), Alphabet::protein());
+    assert_eq!(protein_seqs.alphabet(), Alphabet::protein());
 }
 
 #[test]

--- a/phylo/src/alphabets/mod.rs
+++ b/phylo/src/alphabets/mod.rs
@@ -33,7 +33,37 @@ pub struct Alphabet {
 
 impl Display for Alphabet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name)
+        let capitalised_name = {
+            let mut c = self.name.chars();
+            match c.next() {
+                None => String::new(),
+                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+            }
+        };
+        writeln!(
+            f,
+            "{} sequence alphabet of length {}",
+            capitalised_name,
+            self.len()
+        )?;
+        writeln!(
+            f,
+            "Valid symbols: {}",
+            String::from_utf8_lossy(self.symbols)
+        )?;
+        writeln!(f, "Ambiguous symbols:")?;
+        for &char in self.ambiguous {
+            writeln!(
+                f,
+                "\t{}: {} ",
+                char as char, self.parsimony_sets[char as usize]
+            )?;
+        }
+        writeln!(
+            f,
+            "Possible gap representations: {}",
+            String::from_utf8_lossy(POSSIBLE_GAPS)
+        )
     }
 }
 

--- a/phylo/src/alphabets/mod.rs
+++ b/phylo/src/alphabets/mod.rs
@@ -61,16 +61,17 @@ impl Alphabet {
         &self.conditional_probs[char.to_ascii_uppercase() as usize]
     }
 
-    pub fn empty_freqs(&self) -> FreqVector {
-        FreqVector::zeros(self.conditional_probs[AMB_CHAR as usize].nrows())
-    }
-
     pub fn index(&self, char: &u8) -> usize {
         self.index[*char as usize]
     }
 
     pub fn gap_encoding(&self) -> &FreqVector {
         &self.conditional_probs[AMB_CHAR as usize]
+    }
+
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.symbols.len()
     }
 
     pub fn parsimony_set(&self, char: &u8) -> &ParsimonySet {

--- a/phylo/src/alphabets/mod.rs
+++ b/phylo/src/alphabets/mod.rs
@@ -2,12 +2,15 @@ use std::fmt::Display;
 
 use hashbrown::HashSet;
 use lazy_static::lazy_static;
+use nalgebra::DVector;
 
 use crate::frequencies;
 use crate::substitution_models::FreqVector;
 
 pub mod parsimony_set;
 pub use parsimony_set::*;
+
+type ConditionalProbs = DVector<f64>;
 
 pub static AMINOACIDS: &[u8] = b"ARNDCQEGHILKMFPSTWYV";
 pub static AMB_AMINOACIDS: &[u8] = b"BJZX";
@@ -57,7 +60,7 @@ impl Alphabet {
         self.ambiguous
     }
 
-    pub fn char_encoding(&self, char: u8) -> &FreqVector {
+    pub fn char_encoding(&self, char: u8) -> &ConditionalProbs {
         &self.conditional_probs[char.to_ascii_uppercase() as usize]
     }
 
@@ -65,7 +68,7 @@ impl Alphabet {
         self.index[*char as usize]
     }
 
-    pub fn gap_encoding(&self) -> &FreqVector {
+    pub fn missing_char_encoding(&self) -> &ConditionalProbs {
         &self.conditional_probs[AMB_CHAR as usize]
     }
 

--- a/phylo/src/alphabets/mod.rs
+++ b/phylo/src/alphabets/mod.rs
@@ -38,49 +38,144 @@ impl Display for Alphabet {
 }
 
 impl Alphabet {
+    /// Returns the DNA alphabet as a static reference.
     pub fn dna() -> &'static Self {
         &DNA_ALPHABET
     }
 
+    /// Returns the protein alphabet as a static reference.
     pub fn protein() -> &'static Self {
         &PROTEIN_ALPHABET
     }
 
+    /// Checks if a word is valid in this alphabet, case-insensitive.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// assert!(Alphabet::dna().is_word(b"ACGT"));
+    /// assert!(Alphabet::dna().is_word(b"aCgTx"));
+    /// assert!(Alphabet::protein().is_word(b"ACGTFTH"));
+    /// assert!(!Alphabet::dna().is_word(b"ACGTFTH"));
+    /// ```
     pub fn is_word(&self, word: &[u8]) -> bool {
         word.to_ascii_uppercase()
             .iter()
             .all(|c| self.valid_symbols.contains(c))
     }
 
+    /// Returns the valid and unambiguous symbols of the alphabet.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// assert_eq!(Alphabet::dna().symbols(), b"TCAG");
+    /// assert_eq!(Alphabet::protein().symbols(), b"ARNDCQEGHILKMFPSTWYV");
+    /// ```
     pub fn symbols(&self) -> &[u8] {
         self.symbols
     }
 
+    /// Returns the ambiguous symbols of the alphabet.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// assert_eq!(Alphabet::dna().ambiguous(), b"RYSWKMBDHVNZX");
+    /// assert_eq!(Alphabet::protein().ambiguous(), b"BJZX");
+    /// ```
     pub fn ambiguous(&self) -> &[u8] {
         self.ambiguous
     }
 
+    /// Returns the conditional probability vector for a given character in the alphabet.
+    /// The vector represents the conditional probabilities of observing each symbol in the alphabet given the specified character.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// # use nalgebra::dvector;
+    /// let t_probs = Alphabet::dna().char_encoding(b'T');
+    /// assert_eq!(t_probs, &dvector![1.0, 0.0, 0.0, 0.0]);
+    /// let amb_probs = Alphabet::dna().char_encoding(b'X');
+    /// assert_eq!(amb_probs, &dvector![1.0, 1.0, 1.0, 1.0]);
+    /// ```
     pub fn char_encoding(&self, char: u8) -> &ConditionalProbs {
         &self.conditional_probs[char.to_ascii_uppercase() as usize]
     }
 
+    /// Returns the index mapping for the alphabet.
+    /// The index maps ASCII character codes to their respective indices in the alphabet, case-insensitive.
+    /// Used to maintain consistent ordering in frequency vectors and substitution matrices.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// assert_eq!(Alphabet::dna().index(&b'T'), 0);
+    /// assert_eq!(Alphabet::dna().index(&b'c'), 1);
+    /// assert_eq!(Alphabet::dna().index(&b'A'), 2);
+    /// assert_eq!(Alphabet::dna().index(&b'g'), 3);
+    /// assert_eq!(Alphabet::protein().index(&b'R'), 1);
+    /// assert_eq!(Alphabet::protein().index(&b'w'), 17);
+    /// ```
     pub fn index(&self, char: &u8) -> usize {
         self.index[*char as usize]
     }
 
+    /// Returns the conditional probability vector for the gap character in the alphabet, encoded as missing data.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// # use nalgebra::dvector;
+    /// let gap_probs = Alphabet::dna().missing_char_encoding();
+    /// assert_eq!(gap_probs, &dvector![1.0, 1.0, 1.0, 1.0]);
+    /// let amb_probs = Alphabet::dna().char_encoding(b'X');
+    /// assert_eq!(gap_probs, amb_probs);
+    /// ```
     pub fn missing_char_encoding(&self) -> &ConditionalProbs {
         &self.conditional_probs[AMB_CHAR as usize]
     }
 
+    /// Returns the number of symbols in the alphabet, not including ambiguous characters or gaps.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// assert_eq!(Alphabet::dna().len(), 4);
+    /// assert_eq!(Alphabet::protein().len(), 20);
+    /// ```
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.symbols.len()
     }
 
+    /// Returns the parsimony set for a given character in the alphabet.
+    /// The parsimony set represents the set of unambiguous symbols that the character can represent.
+    /// For example, in the DNA alphabet, the character 'R' represents the set {'A', 'G'}.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// # use phylo::alphabets::ParsimonySet;
+    /// let r_set = Alphabet::dna().parsimony_set(&b'R');
+    /// assert_eq!(format!("{r_set}"), "[AG]");
+    /// let z_set = Alphabet::protein().parsimony_set(&b'Z');
+    /// assert_eq!(format!("{z_set}"), "[EQ]");
+    /// ```
     pub fn parsimony_set(&self, char: &u8) -> &ParsimonySet {
         &self.parsimony_sets[*char as usize]
     }
 
+    /// Returns the parsimony set representing a gap character in the alphabet.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// # use phylo::alphabets::ParsimonySet;
+    /// let gap_set = Alphabet::dna().gap_set();
+    /// assert_eq!(format!("{gap_set}"), "[-]");
+    /// ```
     pub fn gap_set(&self) -> &ParsimonySet {
         &GAP_SET
     }

--- a/phylo/src/alphabets/mod.rs
+++ b/phylo/src/alphabets/mod.rs
@@ -88,20 +88,17 @@ impl Alphabet {
         self.ambiguous
     }
 
-    /// Returns the conditional probability vector for a given character in the alphabet.
-    /// The vector represents the conditional probabilities of observing each symbol in the alphabet given the specified character.
+    /// Returns the number of symbols in the alphabet, not including ambiguous characters or gaps.
     ///
     /// Example:
     /// ```
     /// # use phylo::alphabets::Alphabet;
-    /// # use nalgebra::dvector;
-    /// let t_probs = Alphabet::dna().char_encoding(b'T');
-    /// assert_eq!(t_probs, &dvector![1.0, 0.0, 0.0, 0.0]);
-    /// let amb_probs = Alphabet::dna().char_encoding(b'X');
-    /// assert_eq!(amb_probs, &dvector![1.0, 1.0, 1.0, 1.0]);
+    /// assert_eq!(Alphabet::dna().len(), 4);
+    /// assert_eq!(Alphabet::protein().len(), 20);
     /// ```
-    pub fn char_encoding(&self, char: u8) -> &ConditionalProbs {
-        &self.conditional_probs[char.to_ascii_uppercase() as usize]
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.symbols.len()
     }
 
     /// Returns the index mapping for the alphabet.
@@ -122,6 +119,22 @@ impl Alphabet {
         self.index[*char as usize]
     }
 
+    /// Returns the conditional probability vector for a given character in the alphabet.
+    /// The vector represents the conditional probabilities of observing each symbol in the alphabet given the specified character.
+    ///
+    /// Example:
+    /// ```
+    /// # use phylo::alphabets::Alphabet;
+    /// # use nalgebra::dvector;
+    /// let t_probs = Alphabet::dna().char_encoding(b'T');
+    /// assert_eq!(t_probs, &dvector![1.0, 0.0, 0.0, 0.0]);
+    /// let amb_probs = Alphabet::dna().char_encoding(b'X');
+    /// assert_eq!(amb_probs, &dvector![1.0, 1.0, 1.0, 1.0]);
+    /// ```
+    pub fn char_encoding(&self, char: u8) -> &ConditionalProbs {
+        &self.conditional_probs[char.to_ascii_uppercase() as usize]
+    }
+
     /// Returns the conditional probability vector for the gap character in the alphabet, encoded as missing data.
     ///
     /// Example:
@@ -135,19 +148,6 @@ impl Alphabet {
     /// ```
     pub fn missing_char_encoding(&self) -> &ConditionalProbs {
         &self.conditional_probs[AMB_CHAR as usize]
-    }
-
-    /// Returns the number of symbols in the alphabet, not including ambiguous characters or gaps.
-    ///
-    /// Example:
-    /// ```
-    /// # use phylo::alphabets::Alphabet;
-    /// assert_eq!(Alphabet::dna().len(), 4);
-    /// assert_eq!(Alphabet::protein().len(), 20);
-    /// ```
-    #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> usize {
-        self.symbols.len()
     }
 
     /// Returns the parsimony set for a given character in the alphabet.

--- a/phylo/src/alphabets/mod.rs
+++ b/phylo/src/alphabets/mod.rs
@@ -35,37 +35,13 @@ impl Display for Alphabet {
     }
 }
 
-impl Default for Alphabet {
-    fn default() -> Self {
-        Alphabet::dna()
-    }
-}
-
 impl Alphabet {
-    pub fn dna() -> Self {
-        Alphabet {
-            name: "DNA",
-            symbols: NUCLEOTIDES,
-            ambiguous: AMB_NUCLEOTIDES,
-            index: &NUCLEOTIDE_INDEX,
-            valid_symbols: &VALID_NUCLEOTIDES,
-            conditional_probs: &NUCL_COND_PROBS,
-            parsimony_sets: &NUCL_PARSIMONY_SETS,
-            full_set: &NUCL_FULL_SET,
-        }
+    pub fn dna() -> &'static Self {
+        &DNA_ALPHABET
     }
 
-    pub fn protein() -> Self {
-        Alphabet {
-            name: "protein",
-            symbols: AMINOACIDS,
-            ambiguous: AMB_AMINOACIDS,
-            index: &AMINOACID_INDEX,
-            valid_symbols: &VALID_AMINOACIDS,
-            conditional_probs: &AA_COND_PROBS,
-            parsimony_sets: &AA_PARSIMONY_SETS,
-            full_set: &AA_FULL_SET,
-        }
+    pub fn protein() -> &'static Self {
+        &PROTEIN_ALPHABET
     }
 
     pub fn is_word(&self, word: &[u8]) -> bool {
@@ -111,8 +87,8 @@ impl Alphabet {
     }
 }
 
-pub fn dna_alphabet() -> Alphabet {
-    Alphabet {
+lazy_static! {
+    pub static ref DNA_ALPHABET: Alphabet = Alphabet {
         name: "DNA",
         symbols: NUCLEOTIDES,
         ambiguous: AMB_NUCLEOTIDES,
@@ -121,11 +97,8 @@ pub fn dna_alphabet() -> Alphabet {
         conditional_probs: &NUCL_COND_PROBS,
         parsimony_sets: &NUCL_PARSIMONY_SETS,
         full_set: &NUCL_FULL_SET,
-    }
-}
-
-pub fn protein_alphabet() -> Alphabet {
-    Alphabet {
+    };
+    pub static ref PROTEIN_ALPHABET: Alphabet = Alphabet {
         name: "protein",
         symbols: AMINOACIDS,
         ambiguous: AMB_AMINOACIDS,
@@ -134,10 +107,7 @@ pub fn protein_alphabet() -> Alphabet {
         conditional_probs: &AA_COND_PROBS,
         parsimony_sets: &AA_PARSIMONY_SETS,
         full_set: &AA_FULL_SET,
-    }
-}
-
-lazy_static! {
+    };
     pub static ref NUCLEOTIDE_INDEX: [usize; 255] = {
         let mut index = [0; 255];
         for (i, char) in NUCLEOTIDES.iter().enumerate() {

--- a/phylo/src/alphabets/mod.rs
+++ b/phylo/src/alphabets/mod.rs
@@ -17,7 +17,7 @@ pub static AMB_CHAR: u8 = b'X';
 pub static GAP: u8 = b'-';
 pub static POSSIBLE_GAPS: &[u8] = b"_*-";
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Alphabet {
     name: &'static str,
     symbols: &'static [u8],
@@ -35,7 +35,39 @@ impl Display for Alphabet {
     }
 }
 
+impl Default for Alphabet {
+    fn default() -> Self {
+        Alphabet::dna()
+    }
+}
+
 impl Alphabet {
+    pub fn dna() -> Self {
+        Alphabet {
+            name: "DNA",
+            symbols: NUCLEOTIDES,
+            ambiguous: AMB_NUCLEOTIDES,
+            index: &NUCLEOTIDE_INDEX,
+            valid_symbols: &VALID_NUCLEOTIDES,
+            conditional_probs: &NUCL_COND_PROBS,
+            parsimony_sets: &NUCL_PARSIMONY_SETS,
+            full_set: &NUCL_FULL_SET,
+        }
+    }
+
+    pub fn protein() -> Self {
+        Alphabet {
+            name: "protein",
+            symbols: AMINOACIDS,
+            ambiguous: AMB_AMINOACIDS,
+            index: &AMINOACID_INDEX,
+            valid_symbols: &VALID_AMINOACIDS,
+            conditional_probs: &AA_COND_PROBS,
+            parsimony_sets: &AA_PARSIMONY_SETS,
+            full_set: &AA_FULL_SET,
+        }
+    }
+
     pub fn is_word(&self, word: &[u8]) -> bool {
         word.to_ascii_uppercase()
             .iter()

--- a/phylo/src/alphabets/mod.rs
+++ b/phylo/src/alphabets/mod.rs
@@ -26,7 +26,6 @@ pub struct Alphabet {
     valid_symbols: &'static HashSet<u8>,
     conditional_probs: &'static [FreqVector],
     parsimony_sets: &'static [ParsimonySet],
-    full_set: &'static ParsimonySet,
 }
 
 impl Display for Alphabet {
@@ -78,10 +77,6 @@ impl Alphabet {
         &self.parsimony_sets[*char as usize]
     }
 
-    pub fn full_set(&self) -> &ParsimonySet {
-        self.full_set
-    }
-
     pub fn gap_set(&self) -> &ParsimonySet {
         &GAP_SET
     }
@@ -96,7 +91,6 @@ lazy_static! {
         valid_symbols: &VALID_NUCLEOTIDES,
         conditional_probs: &NUCL_COND_PROBS,
         parsimony_sets: &NUCL_PARSIMONY_SETS,
-        full_set: &NUCL_FULL_SET,
     };
     pub static ref PROTEIN_ALPHABET: Alphabet = Alphabet {
         name: "protein",
@@ -106,7 +100,6 @@ lazy_static! {
         valid_symbols: &VALID_AMINOACIDS,
         conditional_probs: &AA_COND_PROBS,
         parsimony_sets: &AA_PARSIMONY_SETS,
-        full_set: &AA_FULL_SET,
     };
     pub static ref NUCLEOTIDE_INDEX: [usize; 255] = {
         let mut index = [0; 255];
@@ -140,7 +133,6 @@ lazy_static! {
         }
         map
     };
-    pub static ref NUCL_FULL_SET: ParsimonySet = ParsimonySet::from_slice(NUCLEOTIDES);
     pub static ref GAP_SET: ParsimonySet = ParsimonySet::from_slice(&[GAP]);
 }
 
@@ -219,7 +211,6 @@ lazy_static! {
         }
         map
     };
-    pub static ref AA_FULL_SET: ParsimonySet = ParsimonySet::from_slice(AMINOACIDS);
 }
 
 fn aa_cond_probs(char: u8) -> FreqVector {

--- a/phylo/src/alphabets/parsimony_set.rs
+++ b/phylo/src/alphabets/parsimony_set.rs
@@ -7,7 +7,7 @@ use itertools::join;
 use crate::alphabets::GAP;
 
 #[repr(transparent)]
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ParsimonySet {
     pub s: HashSet<u8>,
 }

--- a/phylo/src/alphabets/tests.rs
+++ b/phylo/src/alphabets/tests.rs
@@ -1,7 +1,7 @@
 use rstest::*;
 
 use crate::alphabets::{
-    Alphabet, ParsimonySet, AMB_AMINOACIDS, AMB_NUCLEOTIDES, AMINOACIDS, NUCLEOTIDES,
+    Alphabet, ParsimonySet, AMB_AMINOACIDS, AMB_NUCLEOTIDES, AMINOACIDS, NUCLEOTIDES, POSSIBLE_GAPS,
 };
 use crate::record_wo_desc as record;
 
@@ -145,5 +145,47 @@ fn ambiguous_sets() {
     }
     for char in AMB_AMINOACIDS.iter() {
         assert!(!(full_set & prot.parsimony_set(char)).is_empty());
+    }
+}
+
+#[test]
+fn dna_alphabet_display() {
+    let dna = Alphabet::dna();
+    let display = format!("{dna}");
+    let mut lines = display.split('\n');
+    let name = lines.next().unwrap();
+    assert!(name.contains("DNA"));
+    assert!(name.contains("length 4"));
+
+    let valid_symbols_display = lines.next().unwrap();
+    assert!(valid_symbols_display.contains("Valid symbols:"));
+    for char in NUCLEOTIDES {
+        assert!(valid_symbols_display.contains(&(*char as char).to_string()));
+    }
+
+    let other_symbol_display = lines.collect::<String>();
+    for char in AMB_NUCLEOTIDES.iter().chain(POSSIBLE_GAPS.iter()) {
+        assert!(other_symbol_display.contains(&(*char as char).to_string()));
+    }
+}
+
+#[test]
+fn protein_alphabet_display() {
+    let prot = Alphabet::protein();
+    let display = format!("{prot}");
+    let mut lines = display.split('\n');
+    let name = lines.next().unwrap();
+    assert!(name.contains("Protein"));
+    assert!(name.contains("length 20"));
+
+    let valid_symbols_display = lines.next().unwrap();
+    assert!(valid_symbols_display.contains("Valid symbols:"));
+    for char in AMINOACIDS {
+        assert!(valid_symbols_display.contains(&(*char as char).to_string()));
+    }
+
+    let other_symbol_display = lines.collect::<String>();
+    for char in AMB_AMINOACIDS.iter().chain(POSSIBLE_GAPS.iter()) {
+        assert!(other_symbol_display.contains(&(*char as char).to_string()));
     }
 }

--- a/phylo/src/alphabets/tests.rs
+++ b/phylo/src/alphabets/tests.rs
@@ -1,8 +1,7 @@
 use rstest::*;
 
 use crate::alphabets::{
-    dna_alphabet, protein_alphabet, ParsimonySet, AMB_AMINOACIDS, AMB_NUCLEOTIDES, AMINOACIDS,
-    NUCLEOTIDES,
+    Alphabet, ParsimonySet, AMB_AMINOACIDS, AMB_NUCLEOTIDES, AMINOACIDS, NUCLEOTIDES,
 };
 use crate::record_wo_desc as record;
 
@@ -14,7 +13,7 @@ fn parsimony_set_iters() {
     let from_into_iter = set.into_iter().collect::<Vec<u8>>();
     assert_eq!(from_into_iter.len(), 4);
 
-    let set = dna_alphabet().parsimony_set(&b'X').clone();
+    let set = Alphabet::dna().parsimony_set(&b'X').clone();
     let from_iter = set.iter().cloned().collect::<Vec<u8>>();
     assert_eq!(from_iter.len(), 4);
     let from_into_iter = set.into_iter().collect::<Vec<u8>>();
@@ -28,7 +27,7 @@ fn dna_sets() {
     let sets = record
         .seq()
         .iter()
-        .map(|c| dna_alphabet().parsimony_set(c).clone())
+        .map(|c| Alphabet::dna().parsimony_set(c).clone())
         .collect::<Vec<_>>();
     assert_eq!(sets.len(), 11);
     assert_eq!(sets[0], sets[1]);
@@ -49,7 +48,7 @@ fn protein_sets() {
     let sets = record
         .seq()
         .iter()
-        .map(|c| protein_alphabet().parsimony_set(c).clone())
+        .map(|c| Alphabet::protein().parsimony_set(c).clone())
         .collect::<Vec<_>>();
     assert_eq!(sets.len(), 11);
     assert_eq!(sets[0], sets[1]);
@@ -62,7 +61,7 @@ fn protein_sets() {
 
 #[test]
 fn dna_characters() {
-    let dna = dna_alphabet();
+    let dna = Alphabet::dna();
     assert_eq!(dna.parsimony_set(&b'N'), dna.parsimony_set(&b'X'));
     assert_eq!(
         &(dna.parsimony_set(&b'A') | dna.parsimony_set(&b'C'))
@@ -93,7 +92,7 @@ fn dna_characters() {
 
 #[test]
 fn protein_characters() {
-    let prot = protein_alphabet();
+    let prot = Alphabet::protein();
     assert_eq!(prot.parsimony_set(&b'X'), prot.parsimony_set(&b'O'));
     assert_eq!(prot.parsimony_set(&b'-'), &ParsimonySet::gap());
     assert!(prot
@@ -129,7 +128,7 @@ fn test_parsimony_set_printing(#[case] input: &[u8], #[case] output: &str) {
 
 #[test]
 fn full_sets() {
-    let dna = dna_alphabet();
+    let dna = Alphabet::dna();
     let full_set = dna.full_set();
     for char in NUCLEOTIDES.iter() {
         assert!(full_set.contains(char));
@@ -138,7 +137,7 @@ fn full_sets() {
         assert!(!(full_set & dna.parsimony_set(char)).is_empty());
     }
 
-    let prot = protein_alphabet();
+    let prot = Alphabet::protein();
     let full_set = prot.full_set();
     for char in AMINOACIDS.iter() {
         assert!(full_set.contains(char));

--- a/phylo/src/alphabets/tests.rs
+++ b/phylo/src/alphabets/tests.rs
@@ -127,9 +127,10 @@ fn test_parsimony_set_printing(#[case] input: &[u8], #[case] output: &str) {
 }
 
 #[test]
-fn full_sets() {
+fn ambiguous_sets() {
     let dna = Alphabet::dna();
-    let full_set = dna.full_set();
+    let full_set = dna.parsimony_set(&b'X');
+    assert_eq!(full_set, dna.parsimony_set(&b'N'));
     for char in NUCLEOTIDES.iter() {
         assert!(full_set.contains(char));
     }
@@ -138,7 +139,7 @@ fn full_sets() {
     }
 
     let prot = Alphabet::protein();
-    let full_set = prot.full_set();
+    let full_set = prot.parsimony_set(&b'X');
     for char in AMINOACIDS.iter() {
         assert!(full_set.contains(char));
     }

--- a/phylo/src/evolutionary_models/mod.rs
+++ b/phylo/src/evolutionary_models/mod.rs
@@ -21,7 +21,9 @@ pub trait EvoModel: Display + DynClone {
     fn freqs(&self) -> &FreqVector;
     fn set_freqs(&mut self, pi: FreqVector);
     fn n(&self) -> usize;
-    fn alphabet(&self) -> &Alphabet;
+    fn alphabet() -> &'static Alphabet
+    where
+        Self: Sized;
 }
 
 dyn_clone::clone_trait_object!(EvoModel);

--- a/phylo/src/io/mod.rs
+++ b/phylo/src/io/mod.rs
@@ -8,7 +8,7 @@ use anyhow::bail;
 use bio::io::fasta::{Reader, Record, Writer};
 use log::info;
 
-use crate::alphabets::{protein_alphabet, GAP, POSSIBLE_GAPS};
+use crate::alphabets::{Alphabet, GAP, POSSIBLE_GAPS};
 use crate::tree::{tree_parser, Tree};
 use crate::{record, Result};
 
@@ -64,7 +64,7 @@ pub fn read_sequences(path: impl AsRef<Path> + Debug) -> Result<Vec<Record>> {
             .map(|c| if POSSIBLE_GAPS.contains(c) { GAP } else { *c })
             .collect();
 
-        if !protein_alphabet().is_word(&seq) {
+        if !Alphabet::protein().is_word(&seq) {
             bail!(DataError {
                 message: format!(
                     "Invalid genetic sequence encountered: {}",

--- a/phylo/src/likelihood/tests.rs
+++ b/phylo/src/likelihood/tests.rs
@@ -20,7 +20,6 @@ fn search_costs_equal_template<C: ModelSearchCost + TreeSearchCost>(cost: C) {
 
 #[cfg(test)]
 fn test_subst_model<Q: QMatrix + QMatrixMaker>(
-    alpha: &'static Alphabet,
     freqs: &[f64],
     params: &[f64],
 ) -> SubstitutionCost<Q, MSA> {
@@ -29,8 +28,11 @@ fn test_subst_model<Q: QMatrix + QMatrixMaker>(
     let fldr = Path::new("./data");
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
     let records = read_sequences(fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
-    let msa =
-        Alignment::from_aligned(Sequences::with_alphabet(records.clone(), alpha), &tree).unwrap();
+    let msa = Alignment::from_aligned(
+        Sequences::with_alphabet(records.clone(), Q::alphabet()),
+        &tree,
+    )
+    .unwrap();
     let info = PhyloInfo { msa, tree };
 
     let model = SubstModel::<Q>::new(freqs, params);
@@ -39,20 +41,14 @@ fn test_subst_model<Q: QMatrix + QMatrixMaker>(
 
 #[test]
 fn dna_search_costs_equal() {
-    search_costs_equal_template(test_subst_model::<JC69>(Alphabet::dna(), &[], &[]));
-    search_costs_equal_template(test_subst_model::<K80>(Alphabet::dna(), &[], &[2.0]));
-    search_costs_equal_template(test_subst_model::<HKY>(
-        Alphabet::dna(),
-        &[0.22, 0.26, 0.33, 0.19],
-        &[0.5],
-    ));
+    search_costs_equal_template(test_subst_model::<JC69>(&[], &[]));
+    search_costs_equal_template(test_subst_model::<K80>(&[], &[2.0]));
+    search_costs_equal_template(test_subst_model::<HKY>(&[0.22, 0.26, 0.33, 0.19], &[0.5]));
     search_costs_equal_template(test_subst_model::<TN93>(
-        Alphabet::dna(),
         &[0.22, 0.26, 0.33, 0.19],
         &[0.5970915, 0.2940435, 0.00135],
     ));
     search_costs_equal_template(test_subst_model::<GTR>(
-        Alphabet::dna(),
         &[0.1, 0.3, 0.4, 0.2],
         &[5.0, 1.0, 1.0, 1.0, 1.0, 5.0],
     ));
@@ -60,28 +56,27 @@ fn dna_search_costs_equal() {
 
 #[test]
 fn protein_search_costs_equal() {
-    search_costs_equal_template(test_subst_model::<WAG>(Alphabet::protein(), &[], &[]));
-    search_costs_equal_template(test_subst_model::<HIVB>(Alphabet::protein(), &[], &[]));
-    search_costs_equal_template(test_subst_model::<BLOSUM>(Alphabet::protein(), &[], &[]));
+    search_costs_equal_template(test_subst_model::<WAG>(&[], &[]));
+    search_costs_equal_template(test_subst_model::<HIVB>(&[], &[]));
+    search_costs_equal_template(test_subst_model::<BLOSUM>(&[], &[]));
     let freqs = &[1.0 / 20.0; 20];
-    search_costs_equal_template(test_subst_model::<WAG>(Alphabet::protein(), freqs, &[]));
-    search_costs_equal_template(test_subst_model::<HIVB>(Alphabet::protein(), freqs, &[]));
-    search_costs_equal_template(test_subst_model::<BLOSUM>(Alphabet::protein(), freqs, &[]));
+    search_costs_equal_template(test_subst_model::<WAG>(freqs, &[]));
+    search_costs_equal_template(test_subst_model::<HIVB>(freqs, &[]));
+    search_costs_equal_template(test_subst_model::<BLOSUM>(freqs, &[]));
 }
 
 #[cfg(test)]
-fn test_pip_model<Q: QMatrix + QMatrixMaker>(
-    alpha: &'static Alphabet,
-    freqs: &[f64],
-    params: &[f64],
-) -> PIPCost<Q, MSA> {
+fn test_pip_model<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64]) -> PIPCost<Q, MSA> {
     // https://molevolworkshop.github.io/faculty/huelsenbeck/pdf/WoodsHoleHandout.pdf
-
     let fldr = Path::new("./data");
     let records = read_sequences(fldr.join("Huelsenbeck_example_long_DNA.fasta")).unwrap();
 
     let tree = tree!(&fs::read_to_string(fldr.join("Huelsenbeck_example.newick")).unwrap());
-    let msa = MSA::from_aligned(Sequences::with_alphabet(records.clone(), alpha), &tree).unwrap();
+    let msa = MSA::from_aligned(
+        Sequences::with_alphabet(records.clone(), Q::alphabet()),
+        &tree,
+    )
+    .unwrap();
     let info = PhyloInfo { msa, tree };
 
     let model = PIPModel::<Q>::new(freqs, params);
@@ -90,24 +85,17 @@ fn test_pip_model<Q: QMatrix + QMatrixMaker>(
 
 #[test]
 fn dna_pip_search_costs_equal() {
-    search_costs_equal_template(test_pip_model::<JC69>(Alphabet::dna(), &[], &[1.2, 0.5]));
-    search_costs_equal_template(test_pip_model::<K80>(
-        Alphabet::dna(),
-        &[],
-        &[1.2, 0.5, 2.0],
-    ));
+    search_costs_equal_template(test_pip_model::<JC69>(&[], &[1.2, 0.5]));
+    search_costs_equal_template(test_pip_model::<K80>(&[], &[1.2, 0.5, 2.0]));
     search_costs_equal_template(test_pip_model::<HKY>(
-        Alphabet::dna(),
         &[0.22, 0.26, 0.33, 0.19],
         &[1.2, 0.5, 0.5],
     ));
     search_costs_equal_template(test_pip_model::<TN93>(
-        Alphabet::dna(),
         &[0.22, 0.26, 0.33, 0.19],
         &[1.2, 0.5, 0.5970915, 0.2940435, 0.00135],
     ));
     search_costs_equal_template(test_pip_model::<GTR>(
-        Alphabet::dna(),
         &[0.1, 0.3, 0.4, 0.2],
         &[1.2, 0.5, 5.0, 1.0, 1.0, 1.0, 1.0, 5.0],
     ));
@@ -115,33 +103,13 @@ fn dna_pip_search_costs_equal() {
 
 #[test]
 fn protein_pip_search_costs_equal() {
-    search_costs_equal_template(test_pip_model::<WAG>(Alphabet::protein(), &[], &[1.2, 0.5]));
-    search_costs_equal_template(test_pip_model::<HIVB>(
-        Alphabet::protein(),
-        &[],
-        &[1.2, 0.5],
-    ));
-    search_costs_equal_template(test_pip_model::<BLOSUM>(
-        Alphabet::protein(),
-        &[],
-        &[1.2, 0.5],
-    ));
+    search_costs_equal_template(test_pip_model::<WAG>(&[], &[1.2, 0.5]));
+    search_costs_equal_template(test_pip_model::<HIVB>(&[], &[1.2, 0.5]));
+    search_costs_equal_template(test_pip_model::<BLOSUM>(&[], &[1.2, 0.5]));
     let freqs = &[1.0 / 20.0; 20];
-    search_costs_equal_template(test_pip_model::<WAG>(
-        Alphabet::protein(),
-        freqs,
-        &[1.2, 0.5],
-    ));
-    search_costs_equal_template(test_pip_model::<HIVB>(
-        Alphabet::protein(),
-        freqs,
-        &[1.2, 0.5],
-    ));
-    search_costs_equal_template(test_pip_model::<BLOSUM>(
-        Alphabet::protein(),
-        freqs,
-        &[1.2, 0.5],
-    ));
+    search_costs_equal_template(test_pip_model::<WAG>(freqs, &[1.2, 0.5]));
+    search_costs_equal_template(test_pip_model::<HIVB>(freqs, &[1.2, 0.5]));
+    search_costs_equal_template(test_pip_model::<BLOSUM>(freqs, &[1.2, 0.5]));
 }
 
 #[cfg(test)]

--- a/phylo/src/likelihood/tests.rs
+++ b/phylo/src/likelihood/tests.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::alignment::{Alignment, Sequences, MSA};
-use crate::alphabets::{dna_alphabet, protein_alphabet, Alphabet};
+use crate::alphabets::Alphabet;
 use crate::io::read_sequences;
 use crate::likelihood::{ModelSearchCost, TreeSearchCost};
 use crate::phylo_info::PhyloInfo;
@@ -39,20 +39,20 @@ fn test_subst_model<Q: QMatrix + QMatrixMaker>(
 
 #[test]
 fn dna_search_costs_equal() {
-    search_costs_equal_template(test_subst_model::<JC69>(dna_alphabet(), &[], &[]));
-    search_costs_equal_template(test_subst_model::<K80>(dna_alphabet(), &[], &[2.0]));
+    search_costs_equal_template(test_subst_model::<JC69>(Alphabet::dna(), &[], &[]));
+    search_costs_equal_template(test_subst_model::<K80>(Alphabet::dna(), &[], &[2.0]));
     search_costs_equal_template(test_subst_model::<HKY>(
-        dna_alphabet(),
+        Alphabet::dna(),
         &[0.22, 0.26, 0.33, 0.19],
         &[0.5],
     ));
     search_costs_equal_template(test_subst_model::<TN93>(
-        dna_alphabet(),
+        Alphabet::dna(),
         &[0.22, 0.26, 0.33, 0.19],
         &[0.5970915, 0.2940435, 0.00135],
     ));
     search_costs_equal_template(test_subst_model::<GTR>(
-        dna_alphabet(),
+        Alphabet::dna(),
         &[0.1, 0.3, 0.4, 0.2],
         &[5.0, 1.0, 1.0, 1.0, 1.0, 5.0],
     ));
@@ -60,13 +60,13 @@ fn dna_search_costs_equal() {
 
 #[test]
 fn protein_search_costs_equal() {
-    search_costs_equal_template(test_subst_model::<WAG>(protein_alphabet(), &[], &[]));
-    search_costs_equal_template(test_subst_model::<HIVB>(protein_alphabet(), &[], &[]));
-    search_costs_equal_template(test_subst_model::<BLOSUM>(protein_alphabet(), &[], &[]));
+    search_costs_equal_template(test_subst_model::<WAG>(Alphabet::protein(), &[], &[]));
+    search_costs_equal_template(test_subst_model::<HIVB>(Alphabet::protein(), &[], &[]));
+    search_costs_equal_template(test_subst_model::<BLOSUM>(Alphabet::protein(), &[], &[]));
     let freqs = &[1.0 / 20.0; 20];
-    search_costs_equal_template(test_subst_model::<WAG>(protein_alphabet(), freqs, &[]));
-    search_costs_equal_template(test_subst_model::<HIVB>(protein_alphabet(), freqs, &[]));
-    search_costs_equal_template(test_subst_model::<BLOSUM>(protein_alphabet(), freqs, &[]));
+    search_costs_equal_template(test_subst_model::<WAG>(Alphabet::protein(), freqs, &[]));
+    search_costs_equal_template(test_subst_model::<HIVB>(Alphabet::protein(), freqs, &[]));
+    search_costs_equal_template(test_subst_model::<BLOSUM>(Alphabet::protein(), freqs, &[]));
 }
 
 #[cfg(test)]
@@ -90,20 +90,24 @@ fn test_pip_model<Q: QMatrix + QMatrixMaker>(
 
 #[test]
 fn dna_pip_search_costs_equal() {
-    search_costs_equal_template(test_pip_model::<JC69>(dna_alphabet(), &[], &[1.2, 0.5]));
-    search_costs_equal_template(test_pip_model::<K80>(dna_alphabet(), &[], &[1.2, 0.5, 2.0]));
+    search_costs_equal_template(test_pip_model::<JC69>(Alphabet::dna(), &[], &[1.2, 0.5]));
+    search_costs_equal_template(test_pip_model::<K80>(
+        Alphabet::dna(),
+        &[],
+        &[1.2, 0.5, 2.0],
+    ));
     search_costs_equal_template(test_pip_model::<HKY>(
-        dna_alphabet(),
+        Alphabet::dna(),
         &[0.22, 0.26, 0.33, 0.19],
         &[1.2, 0.5, 0.5],
     ));
     search_costs_equal_template(test_pip_model::<TN93>(
-        dna_alphabet(),
+        Alphabet::dna(),
         &[0.22, 0.26, 0.33, 0.19],
         &[1.2, 0.5, 0.5970915, 0.2940435, 0.00135],
     ));
     search_costs_equal_template(test_pip_model::<GTR>(
-        dna_alphabet(),
+        Alphabet::dna(),
         &[0.1, 0.3, 0.4, 0.2],
         &[1.2, 0.5, 5.0, 1.0, 1.0, 1.0, 1.0, 5.0],
     ));
@@ -111,26 +115,30 @@ fn dna_pip_search_costs_equal() {
 
 #[test]
 fn protein_pip_search_costs_equal() {
-    search_costs_equal_template(test_pip_model::<WAG>(protein_alphabet(), &[], &[1.2, 0.5]));
-    search_costs_equal_template(test_pip_model::<HIVB>(protein_alphabet(), &[], &[1.2, 0.5]));
+    search_costs_equal_template(test_pip_model::<WAG>(Alphabet::protein(), &[], &[1.2, 0.5]));
+    search_costs_equal_template(test_pip_model::<HIVB>(
+        Alphabet::protein(),
+        &[],
+        &[1.2, 0.5],
+    ));
     search_costs_equal_template(test_pip_model::<BLOSUM>(
-        protein_alphabet(),
+        Alphabet::protein(),
         &[],
         &[1.2, 0.5],
     ));
     let freqs = &[1.0 / 20.0; 20];
     search_costs_equal_template(test_pip_model::<WAG>(
-        protein_alphabet(),
+        Alphabet::protein(),
         freqs,
         &[1.2, 0.5],
     ));
     search_costs_equal_template(test_pip_model::<HIVB>(
-        protein_alphabet(),
+        Alphabet::protein(),
         freqs,
         &[1.2, 0.5],
     ));
     search_costs_equal_template(test_pip_model::<BLOSUM>(
-        protein_alphabet(),
+        Alphabet::protein(),
         freqs,
         &[1.2, 0.5],
     ));
@@ -157,26 +165,26 @@ fn alphabet_mismatch_subst_model_template<Q: QMatrix + QMatrixMaker>(
 
 #[test]
 fn alphabet_mismatch_subst_model() {
-    alphabet_mismatch_subst_model_template::<JC69>(protein_alphabet(), &[], &[]);
-    alphabet_mismatch_subst_model_template::<K80>(protein_alphabet(), &[], &[2.0]);
+    alphabet_mismatch_subst_model_template::<JC69>(Alphabet::protein(), &[], &[]);
+    alphabet_mismatch_subst_model_template::<K80>(Alphabet::protein(), &[], &[2.0]);
     alphabet_mismatch_subst_model_template::<HKY>(
-        protein_alphabet(),
+        Alphabet::protein(),
         &[0.22, 0.26, 0.33, 0.19],
         &[0.5],
     );
     alphabet_mismatch_subst_model_template::<TN93>(
-        protein_alphabet(),
+        Alphabet::protein(),
         &[0.22, 0.26, 0.33, 0.19],
         &[0.5970915, 0.2940435, 0.00135],
     );
     alphabet_mismatch_subst_model_template::<GTR>(
-        protein_alphabet(),
+        Alphabet::protein(),
         &[0.1, 0.3, 0.4, 0.2],
         &[1.5; 5],
     );
-    alphabet_mismatch_subst_model_template::<WAG>(dna_alphabet(), &[], &[]);
-    alphabet_mismatch_subst_model_template::<BLOSUM>(dna_alphabet(), &[], &[]);
-    alphabet_mismatch_subst_model_template::<HIVB>(dna_alphabet(), &[], &[]);
+    alphabet_mismatch_subst_model_template::<WAG>(Alphabet::dna(), &[], &[]);
+    alphabet_mismatch_subst_model_template::<BLOSUM>(Alphabet::dna(), &[], &[]);
+    alphabet_mismatch_subst_model_template::<HIVB>(Alphabet::dna(), &[], &[]);
 }
 
 #[cfg(test)]
@@ -200,24 +208,24 @@ fn alphabet_mismatch_subst_pip_template<Q: QMatrix + QMatrixMaker>(
 
 #[test]
 fn alphabet_mismatch_pip_model() {
-    alphabet_mismatch_subst_pip_template::<JC69>(protein_alphabet(), &[], &[1.3, 0.5]);
-    alphabet_mismatch_subst_pip_template::<K80>(protein_alphabet(), &[], &[1.3, 0.5, 2.0]);
+    alphabet_mismatch_subst_pip_template::<JC69>(Alphabet::protein(), &[], &[1.3, 0.5]);
+    alphabet_mismatch_subst_pip_template::<K80>(Alphabet::protein(), &[], &[1.3, 0.5, 2.0]);
     alphabet_mismatch_subst_pip_template::<HKY>(
-        protein_alphabet(),
+        Alphabet::protein(),
         &[0.22, 0.26, 0.33, 0.19],
         &[1.3, 0.5, 0.5],
     );
     alphabet_mismatch_subst_pip_template::<TN93>(
-        protein_alphabet(),
+        Alphabet::protein(),
         &[0.22, 0.26, 0.33, 0.19],
         &[1.3, 0.5, 0.5970915, 0.2940435, 0.00135],
     );
     alphabet_mismatch_subst_pip_template::<GTR>(
-        protein_alphabet(),
+        Alphabet::protein(),
         &[0.1, 0.3, 0.4, 0.2],
         &[1.5; 7],
     );
-    alphabet_mismatch_subst_pip_template::<WAG>(dna_alphabet(), &[], &[1.3, 0.5]);
-    alphabet_mismatch_subst_pip_template::<BLOSUM>(dna_alphabet(), &[], &[1.3, 0.5]);
-    alphabet_mismatch_subst_pip_template::<HIVB>(dna_alphabet(), &[], &[1.3, 0.5]);
+    alphabet_mismatch_subst_pip_template::<WAG>(Alphabet::dna(), &[], &[1.3, 0.5]);
+    alphabet_mismatch_subst_pip_template::<BLOSUM>(Alphabet::dna(), &[], &[1.3, 0.5]);
+    alphabet_mismatch_subst_pip_template::<HIVB>(Alphabet::dna(), &[], &[1.3, 0.5]);
 }

--- a/phylo/src/likelihood/tests.rs
+++ b/phylo/src/likelihood/tests.rs
@@ -20,7 +20,7 @@ fn search_costs_equal_template<C: ModelSearchCost + TreeSearchCost>(cost: C) {
 
 #[cfg(test)]
 fn test_subst_model<Q: QMatrix + QMatrixMaker>(
-    alpha: Alphabet,
+    alpha: &'static Alphabet,
     freqs: &[f64],
     params: &[f64],
 ) -> SubstitutionCost<Q, MSA> {
@@ -71,7 +71,7 @@ fn protein_search_costs_equal() {
 
 #[cfg(test)]
 fn test_pip_model<Q: QMatrix + QMatrixMaker>(
-    alpha: Alphabet,
+    alpha: &'static Alphabet,
     freqs: &[f64],
     params: &[f64],
 ) -> PIPCost<Q, MSA> {
@@ -146,7 +146,7 @@ fn protein_pip_search_costs_equal() {
 
 #[cfg(test)]
 fn alphabet_mismatch_subst_model_template<Q: QMatrix + QMatrixMaker>(
-    alpha: Alphabet,
+    alpha: &'static Alphabet,
     freqs: &[f64],
     params: &[f64],
 ) {
@@ -189,7 +189,7 @@ fn alphabet_mismatch_subst_model() {
 
 #[cfg(test)]
 fn alphabet_mismatch_subst_pip_template<Q: QMatrix + QMatrixMaker>(
-    alpha: Alphabet,
+    alpha: &'static Alphabet,
     freqs: &[f64],
     params: &[f64],
 ) {

--- a/phylo/src/optimisers/blen_optimiser_tests.rs
+++ b/phylo/src/optimisers/blen_optimiser_tests.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use approx::assert_relative_eq;
 
 use crate::alignment::{Alignment, Sequences, MSA};
-use crate::alphabets::protein_alphabet;
+use crate::alphabets::Alphabet;
 use crate::likelihood::TreeSearchCost;
 use crate::optimisers::{BranchOptimiser, StopCondition};
 use crate::phylo_info::{PhyloInfo, PhyloInfoBuilder as PIB};
@@ -147,7 +147,7 @@ fn only_gap_sequence() {
     let msa: MSA = Alignment::from_aligned(
         Sequences::with_alphabet(
             vec![record!("284812", b"-"), record!("5207", b"V")],
-            protein_alphabet(),
+            Alphabet::protein(),
         ),
         &tree,
     )

--- a/phylo/src/parsimony/cost/dollo_parsimony_cost.rs
+++ b/phylo/src/parsimony/cost/dollo_parsimony_cost.rs
@@ -232,6 +232,7 @@ impl DolloParsimonyInfo {
 #[cfg_attr(coverage, coverage(off))]
 mod private_tests {
     use crate::alignment::{Alignment, Sequences, MSA};
+    use crate::alphabets::Alphabet;
     use crate::likelihood::TreeSearchCost;
     use crate::parsimony::{DolloParsimonyCost, GapCost, SimpleScoring};
     use crate::phylo_info::PhyloInfo;
@@ -337,7 +338,7 @@ mod private_tests {
                 record!("C", b"-"),
                 record!("D", b"-"),
             ],
-            crate::alphabets::dna_alphabet(),
+            Alphabet::dna(),
         );
 
         let tree = tree!("(((D:1,(A:1,C:0.5)I1:0.5)I4:1,B:2)I0:0);");

--- a/phylo/src/parsimony/mod.rs
+++ b/phylo/src/parsimony/mod.rs
@@ -118,7 +118,7 @@ impl<'a, PS: ParsimonyScoring + Clone> ParsimonyAligner<PS> {
                     Record::with_attrs(rec.id(), rec.desc(), &aligned_seq)
                 })
                 .collect(),
-            *seqs.alphabet(),
+            seqs.alphabet(),
         );
         let alignment = A::from_aligned_unchecked(aligned_seqs, tree);
 

--- a/phylo/src/parsimony/scoring/model_scoring.rs
+++ b/phylo/src/parsimony/scoring/model_scoring.rs
@@ -3,7 +3,8 @@ use std::fmt::Display;
 use log::{debug, info};
 use ordered_float::OrderedFloat;
 
-use crate::alphabets::{Alphabet, ParsimonySet};
+use crate::alphabets::ParsimonySet;
+use crate::evolutionary_models::EvoModel;
 use crate::parsimony::{
     CostMatrix, DiagonalZeros, GapCost, ParsimonyModel, ParsimonyScoring, Rounding,
 };
@@ -18,7 +19,7 @@ pub struct ModelScoringBuilder<P: ParsimonyModel> {
     times: Vec<f64>,
 }
 
-impl<P: ParsimonyModel> ModelScoringBuilder<P> {
+impl<P: ParsimonyModel + EvoModel> ModelScoringBuilder<P> {
     pub fn new(model: P) -> Self {
         ModelScoringBuilder {
             model,
@@ -87,7 +88,6 @@ impl<P: ParsimonyModel> ModelScoringBuilder<P> {
         );
         debug!("The scoring matrices are: {costs:?}");
         Ok(ModelScoring {
-            alphabet: *self.model.alphabet(),
             model: self.model,
             gap: self.gap,
             costs,
@@ -97,7 +97,6 @@ impl<P: ParsimonyModel> ModelScoringBuilder<P> {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModelScoring<P: ParsimonyModel> {
-    alphabet: Alphabet,
     model: P,
     gap: GapCost,
     costs: Vec<(OrderedFloat<f64>, TimeCosts)>,
@@ -145,9 +144,9 @@ impl<P: ParsimonyModel> ModelScoring<P> {
     }
 }
 
-impl<P: ParsimonyModel> ParsimonyScoring for ModelScoring<P> {
+impl<P: ParsimonyModel + EvoModel> ParsimonyScoring for ModelScoring<P> {
     fn r#match(&self, blen: f64, i: &u8, j: &u8) -> f64 {
-        self.scoring(OrderedFloat(blen)).c[(self.alphabet.index(i), self.alphabet.index(j))]
+        self.scoring(OrderedFloat(blen)).c[(P::alphabet().index(i), P::alphabet().index(j))]
     }
 
     fn min_match(&self, blen: f64, i: &ParsimonySet, j: &ParsimonySet) -> f64 {

--- a/phylo/src/phylo_info/mod.rs
+++ b/phylo/src/phylo_info/mod.rs
@@ -124,7 +124,7 @@ impl<A: Alignment> PhyloInfo<A> {
     /// ```
     pub fn freqs(&self) -> FreqVector {
         let alphabet = self.msa.alphabet();
-        let mut freqs = alphabet.empty_freqs();
+        let mut freqs = FreqVector::zeros(alphabet.len());
         for &char in alphabet.symbols().iter().chain(alphabet.ambiguous()) {
             let count = self
                 .msa

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -97,7 +97,8 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
         self
     }
 
-    /// TODO: fix docstring
+    /// Sets the alphabet for the PhyloInfoBuilder struct.
+    /// Returns the PhyloInfoBuilder struct with the required alphabet.
     ///
     /// # Example
     /// ```

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -6,7 +6,7 @@ use log::{info, warn};
 use rand::{Rng, SeedableRng};
 
 use crate::alignment::{Aligner, Alignment, AncestralAlignment, Sequences, MASA, MSA};
-use crate::alphabets::{dna_alphabet, protein_alphabet, Alphabet};
+use crate::alphabets::Alphabet;
 use crate::asr::AncestralSequenceReconstruction;
 use crate::evolutionary_distances::{LevenshteinDNACorrected, LevenshteinProteinCorrected};
 use crate::io::{self, DataError};
@@ -105,8 +105,8 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
     /// use phylo::phylo_info::PhyloInfoBuilder;
     /// use phylo::alignment::{Alignment};
     /// # fn main() -> std::result::Result<(), anyhow::Error> {
-    /// let info = PhyloInfoBuilder::new("./examples/data/sequences_DNA_small.fasta").alphabet(Some(protein_alphabet())).build()?;
-    /// assert_eq!(info.msa.alphabet(), &protein_alphabet());
+    /// let info = PhyloInfoBuilder::new("./examples/data/sequences_DNA_small.fasta").alphabet(Some(Alphabet::protein())).build()?;
+    /// assert_eq!(info.msa.alphabet(), &Alphabet::protein());
     /// # Ok(()) }
     /// ```
     pub fn alphabet(mut self, alphabet: Option<Alphabet>) -> PhyloInfoBuilder<A, AA> {
@@ -234,10 +234,10 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
         sequences: &Sequences,
     ) -> Result<Tree> {
         info!("Building NJ tree from sequences");
-        if sequences.alphabet() == &dna_alphabet() {
+        if sequences.alphabet() == &Alphabet::dna() {
             info!("Using corrected Levenshtein DNA distance for distance calculation");
             NJTreeBuilder::new(LevenshteinDNACorrected {}).build(sequences, rng)
-        } else if sequences.alphabet() == &protein_alphabet() {
+        } else if sequences.alphabet() == &Alphabet::protein() {
             info!("Using corrected Levenshtein protein distance for distance calculation");
             NJTreeBuilder::new(LevenshteinProteinCorrected {}).build(sequences, rng)
         } else {

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -101,12 +101,12 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
     ///
     /// # Example
     /// ```
-    /// use phylo::alphabets::protein_alphabet;
+    /// use phylo::alphabets::Alphabet;
     /// use phylo::phylo_info::PhyloInfoBuilder;
     /// use phylo::alignment::{Alignment};
     /// # fn main() -> std::result::Result<(), anyhow::Error> {
     /// let info = PhyloInfoBuilder::new("./examples/data/sequences_DNA_small.fasta").alphabet(Some(Alphabet::protein())).build()?;
-    /// assert_eq!(info.msa.alphabet(), &Alphabet::protein());
+    /// assert_eq!(info.msa.alphabet(), Alphabet::protein());
     /// # Ok(()) }
     /// ```
     pub fn alphabet(mut self, alphabet: Option<&'static Alphabet>) -> PhyloInfoBuilder<A, AA> {

--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -26,7 +26,7 @@ pub struct PhyloInfoBuilder<A: Alignment, AA: AncestralAlignment> {
     // but since we access the alignment on a regular basis (or do we actually? Since we instead use the encoding)
     aligner: Option<Box<dyn Aligner<A>>>,
     asr: Option<Box<dyn AncestralSequenceReconstruction<A, AA>>>,
-    alphabet: Option<Alphabet>,
+    alphabet: Option<&'static Alphabet>,
 }
 
 impl PhyloInfoBuilder<MSA, MASA> {
@@ -109,7 +109,7 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
     /// assert_eq!(info.msa.alphabet(), &Alphabet::protein());
     /// # Ok(()) }
     /// ```
-    pub fn alphabet(mut self, alphabet: Option<Alphabet>) -> PhyloInfoBuilder<A, AA> {
+    pub fn alphabet(mut self, alphabet: Option<&'static Alphabet>) -> PhyloInfoBuilder<A, AA> {
         self.alphabet = alphabet;
         self
     }
@@ -234,10 +234,10 @@ impl<A: Alignment, AA: AncestralAlignment> PhyloInfoBuilder<A, AA> {
         sequences: &Sequences,
     ) -> Result<Tree> {
         info!("Building NJ tree from sequences");
-        if sequences.alphabet() == &Alphabet::dna() {
+        if sequences.alphabet() == Alphabet::dna() {
             info!("Using corrected Levenshtein DNA distance for distance calculation");
             NJTreeBuilder::new(LevenshteinDNACorrected {}).build(sequences, rng)
-        } else if sequences.alphabet() == &Alphabet::protein() {
+        } else if sequences.alphabet() == Alphabet::protein() {
             info!("Using corrected Levenshtein protein distance for distance calculation");
             NJTreeBuilder::new(LevenshteinProteinCorrected {}).build(sequences, rng)
         } else {

--- a/phylo/src/phylo_info/tests.rs
+++ b/phylo/src/phylo_info/tests.rs
@@ -355,14 +355,14 @@ fn force_protein_alphabet() {
     // If data is severely subsampled it might look like DNA even though it's really protein
     let fldr = Path::new("./data");
     let info = PIB::new(fldr.join("p226.msa.fa")).build().unwrap();
-    assert_eq!(info.msa.alphabet(), &Alphabet::dna());
+    assert_eq!(info.msa.alphabet(), Alphabet::dna());
 
     let fldr = Path::new("./data");
     let info = PIB::new(fldr.join("p226.msa.fa"))
         .alphabet(Some(Alphabet::protein()))
         .build()
         .unwrap();
-    assert_eq!(info.msa.alphabet(), &Alphabet::protein());
+    assert_eq!(info.msa.alphabet(), Alphabet::protein());
 }
 
 #[test]

--- a/phylo/src/phylo_info/tests.rs
+++ b/phylo/src/phylo_info/tests.rs
@@ -5,7 +5,7 @@ use approx::assert_relative_eq;
 use assert_matches::assert_matches;
 
 use crate::alignment::{Alignment, AncestralAlignment, Sequences, MSA};
-use crate::alphabets::{dna_alphabet, protein_alphabet, NUCLEOTIDES};
+use crate::alphabets::{Alphabet, NUCLEOTIDES};
 use crate::io::{read_sequences, DataError};
 use crate::phylo_info::{PhyloInfo, PhyloInfoBuilder as PIB};
 use crate::substitution_models::FreqVector;
@@ -355,14 +355,14 @@ fn force_protein_alphabet() {
     // If data is severely subsampled it might look like DNA even though it's really protein
     let fldr = Path::new("./data");
     let info = PIB::new(fldr.join("p226.msa.fa")).build().unwrap();
-    assert_eq!(info.msa.alphabet(), &dna_alphabet());
+    assert_eq!(info.msa.alphabet(), &Alphabet::dna());
 
     let fldr = Path::new("./data");
     let info = PIB::new(fldr.join("p226.msa.fa"))
-        .alphabet(Some(protein_alphabet()))
+        .alphabet(Some(Alphabet::protein()))
         .build()
         .unwrap();
-    assert_eq!(info.msa.alphabet(), &protein_alphabet());
+    assert_eq!(info.msa.alphabet(), &Alphabet::protein());
 }
 
 #[test]

--- a/phylo/src/pip_model/mod.rs
+++ b/phylo/src/pip_model/mod.rs
@@ -150,8 +150,8 @@ impl<Q: QMatrix> EvoModel for PIPModel<Q> {
         self.subst_q.n() + 1
     }
 
-    fn alphabet(&self) -> &Alphabet {
-        self.subst_q.alphabet()
+    fn alphabet() -> &'static Alphabet {
+        Q::alphabet()
     }
 }
 
@@ -235,7 +235,7 @@ impl<Q: QMatrix, A: Alignment> PIPCostBuilder<Q, A> {
     }
 
     pub fn build(self) -> Result<PIPCost<Q, A>> {
-        if self.info.msa.alphabet() != self.model.alphabet() {
+        if self.info.msa.alphabet() != Q::alphabet() {
             bail!("Alphabet mismatch between model and alignment");
         }
 

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -856,7 +856,7 @@ fn blen_leading_to_minusinf() {
 }
 
 #[cfg(test)]
-fn setup_test_info(alphabet: Alphabet) -> PhyloInfo<MSA> {
+fn setup_test_info(alphabet: &'static Alphabet) -> PhyloInfo<MSA> {
     let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
     let msa = MSA::from_aligned(
         Sequences::with_alphabet(
@@ -875,7 +875,7 @@ fn setup_test_info(alphabet: Alphabet) -> PhyloInfo<MSA> {
 }
 
 #[cfg(test)]
-fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static Alphabet) {
     use crate::likelihood::TreeSearchCost;
 
     let info = setup_test_info(alphabet);
@@ -912,7 +912,7 @@ fn dirty_tree_costs_match() {
 }
 
 #[cfg(test)]
-fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static Alphabet) {
     use crate::likelihood::TreeSearchCost;
 
     let info = setup_test_info(alphabet);
@@ -958,7 +958,9 @@ fn dirty_branch_costs_match() {
 }
 
 #[cfg(test)]
-fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
+    alphabet: &'static Alphabet,
+) {
     let info = setup_test_info(alphabet);
 
     let model = PIPModel::<Q>::new(&[], &[1.0]);
@@ -991,7 +993,7 @@ fn modify_model_params_costs_match() {
 
 #[cfg(test)]
 fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
-    alphabet: Alphabet,
+    alphabet: &'static Alphabet,
     freqs: FreqVector,
 ) {
     let info = setup_test_info(alphabet);

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -875,10 +875,10 @@ fn setup_test_info(alphabet: &'static Alphabet) -> PhyloInfo<MSA> {
 }
 
 #[cfg(test)]
-fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static Alphabet) {
+fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>() {
     use crate::likelihood::TreeSearchCost;
 
-    let info = setup_test_info(alphabet);
+    let info = setup_test_info(Q::alphabet());
 
     let model = PIPModel::<Q>::new(&[], &[]);
     let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
@@ -900,22 +900,22 @@ fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static
 
 #[test]
 fn dirty_tree_costs_match() {
-    dirty_tree_costs_match_template::<JC69>(Alphabet::dna());
-    dirty_tree_costs_match_template::<K80>(Alphabet::dna());
-    dirty_tree_costs_match_template::<HKY>(Alphabet::dna());
-    dirty_tree_costs_match_template::<TN93>(Alphabet::dna());
-    dirty_tree_costs_match_template::<GTR>(Alphabet::dna());
+    dirty_tree_costs_match_template::<JC69>();
+    dirty_tree_costs_match_template::<K80>();
+    dirty_tree_costs_match_template::<HKY>();
+    dirty_tree_costs_match_template::<TN93>();
+    dirty_tree_costs_match_template::<GTR>();
 
-    dirty_tree_costs_match_template::<WAG>(Alphabet::protein());
-    dirty_tree_costs_match_template::<HIVB>(Alphabet::protein());
-    dirty_tree_costs_match_template::<BLOSUM>(Alphabet::protein());
+    dirty_tree_costs_match_template::<WAG>();
+    dirty_tree_costs_match_template::<HIVB>();
+    dirty_tree_costs_match_template::<BLOSUM>();
 }
 
 #[cfg(test)]
-fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static Alphabet) {
+fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>() {
     use crate::likelihood::TreeSearchCost;
 
-    let info = setup_test_info(alphabet);
+    let info = setup_test_info(Q::alphabet());
 
     let model = PIPModel::<Q>::new(&[], &[]);
     let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
@@ -946,22 +946,20 @@ fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'stat
 
 #[test]
 fn dirty_branch_costs_match() {
-    dirty_branch_costs_match_template::<JC69>(Alphabet::dna());
-    dirty_branch_costs_match_template::<K80>(Alphabet::dna());
-    dirty_branch_costs_match_template::<HKY>(Alphabet::dna());
-    dirty_branch_costs_match_template::<TN93>(Alphabet::dna());
-    dirty_branch_costs_match_template::<GTR>(Alphabet::dna());
+    dirty_branch_costs_match_template::<JC69>();
+    dirty_branch_costs_match_template::<K80>();
+    dirty_branch_costs_match_template::<HKY>();
+    dirty_branch_costs_match_template::<TN93>();
+    dirty_branch_costs_match_template::<GTR>();
 
-    dirty_branch_costs_match_template::<WAG>(Alphabet::protein());
-    dirty_branch_costs_match_template::<HIVB>(Alphabet::protein());
-    dirty_branch_costs_match_template::<BLOSUM>(Alphabet::protein());
+    dirty_branch_costs_match_template::<WAG>();
+    dirty_branch_costs_match_template::<HIVB>();
+    dirty_branch_costs_match_template::<BLOSUM>();
 }
 
 #[cfg(test)]
-fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
-    alphabet: &'static Alphabet,
-) {
-    let info = setup_test_info(alphabet);
+fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>() {
+    let info = setup_test_info(Q::alphabet());
 
     let model = PIPModel::<Q>::new(&[], &[1.0]);
     let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
@@ -985,18 +983,15 @@ fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
 #[test]
 fn modify_model_params_costs_match() {
     // does not apply to JC69, WAG, HIVB, BLOSUM which have no params
-    modify_model_params_costs_match_template::<K80>(Alphabet::dna());
-    modify_model_params_costs_match_template::<HKY>(Alphabet::dna());
-    modify_model_params_costs_match_template::<TN93>(Alphabet::dna());
-    modify_model_params_costs_match_template::<GTR>(Alphabet::dna());
+    modify_model_params_costs_match_template::<K80>();
+    modify_model_params_costs_match_template::<HKY>();
+    modify_model_params_costs_match_template::<TN93>();
+    modify_model_params_costs_match_template::<GTR>();
 }
 
 #[cfg(test)]
-fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
-    alphabet: &'static Alphabet,
-    freqs: FreqVector,
-) {
-    let info = setup_test_info(alphabet);
+fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(freqs: FreqVector) {
+    let info = setup_test_info(Q::alphabet());
 
     let model = PIPModel::<Q>::new(&[], &[]);
     let mut c = PIPB::new(model.clone(), info.clone()).build().unwrap();
@@ -1021,12 +1016,12 @@ fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
 fn modify_model_freqs_costs_match() {
     // does not apply to JC69 and K80 which have no freqs
     let new_dna_freqs = frequencies!(&[0.1, 0.1, 0.1, 0.7]);
-    modify_model_freqs_costs_match_template::<HKY>(Alphabet::dna(), new_dna_freqs.clone());
-    modify_model_freqs_costs_match_template::<TN93>(Alphabet::dna(), new_dna_freqs.clone());
-    modify_model_freqs_costs_match_template::<GTR>(Alphabet::dna(), new_dna_freqs);
+    modify_model_freqs_costs_match_template::<HKY>(new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<TN93>(new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<GTR>(new_dna_freqs);
 
     let new_aa_freqs = frequencies!(&[0.05; 20]);
-    modify_model_freqs_costs_match_template::<WAG>(Alphabet::protein(), new_aa_freqs.clone());
-    modify_model_freqs_costs_match_template::<BLOSUM>(Alphabet::protein(), new_aa_freqs.clone());
-    modify_model_freqs_costs_match_template::<HIVB>(Alphabet::protein(), new_aa_freqs);
+    modify_model_freqs_costs_match_template::<WAG>(new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<BLOSUM>(new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<HIVB>(new_aa_freqs);
 }

--- a/phylo/src/pip_model/tests.rs
+++ b/phylo/src/pip_model/tests.rs
@@ -4,9 +4,7 @@ use approx::assert_relative_eq;
 use nalgebra::{DMatrix, DVector};
 
 use crate::alignment::{Alignment, Sequences, MSA};
-use crate::alphabets::{
-    dna_alphabet, protein_alphabet, Alphabet, AMINOACIDS as aas, GAP, NUCLEOTIDES as nucls,
-};
+use crate::alphabets::{Alphabet, AMINOACIDS as aas, GAP, NUCLEOTIDES as nucls};
 use crate::evolutionary_models::EvoModel;
 use crate::io::read_sequences;
 use crate::likelihood::ModelSearchCost;
@@ -842,7 +840,7 @@ fn blen_leading_to_minusinf() {
                 record!("284591", b"W"),
                 record!("284812", b"W"),
             ],
-            protein_alphabet(),
+            Alphabet::protein(),
         ),
         &tree,
     )
@@ -902,15 +900,15 @@ fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet
 
 #[test]
 fn dirty_tree_costs_match() {
-    dirty_tree_costs_match_template::<JC69>(dna_alphabet());
-    dirty_tree_costs_match_template::<K80>(dna_alphabet());
-    dirty_tree_costs_match_template::<HKY>(dna_alphabet());
-    dirty_tree_costs_match_template::<TN93>(dna_alphabet());
-    dirty_tree_costs_match_template::<GTR>(dna_alphabet());
+    dirty_tree_costs_match_template::<JC69>(Alphabet::dna());
+    dirty_tree_costs_match_template::<K80>(Alphabet::dna());
+    dirty_tree_costs_match_template::<HKY>(Alphabet::dna());
+    dirty_tree_costs_match_template::<TN93>(Alphabet::dna());
+    dirty_tree_costs_match_template::<GTR>(Alphabet::dna());
 
-    dirty_tree_costs_match_template::<WAG>(protein_alphabet());
-    dirty_tree_costs_match_template::<HIVB>(protein_alphabet());
-    dirty_tree_costs_match_template::<BLOSUM>(protein_alphabet());
+    dirty_tree_costs_match_template::<WAG>(Alphabet::protein());
+    dirty_tree_costs_match_template::<HIVB>(Alphabet::protein());
+    dirty_tree_costs_match_template::<BLOSUM>(Alphabet::protein());
 }
 
 #[cfg(test)]
@@ -948,15 +946,15 @@ fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphab
 
 #[test]
 fn dirty_branch_costs_match() {
-    dirty_branch_costs_match_template::<JC69>(dna_alphabet());
-    dirty_branch_costs_match_template::<K80>(dna_alphabet());
-    dirty_branch_costs_match_template::<HKY>(dna_alphabet());
-    dirty_branch_costs_match_template::<TN93>(dna_alphabet());
-    dirty_branch_costs_match_template::<GTR>(dna_alphabet());
+    dirty_branch_costs_match_template::<JC69>(Alphabet::dna());
+    dirty_branch_costs_match_template::<K80>(Alphabet::dna());
+    dirty_branch_costs_match_template::<HKY>(Alphabet::dna());
+    dirty_branch_costs_match_template::<TN93>(Alphabet::dna());
+    dirty_branch_costs_match_template::<GTR>(Alphabet::dna());
 
-    dirty_branch_costs_match_template::<WAG>(protein_alphabet());
-    dirty_branch_costs_match_template::<HIVB>(protein_alphabet());
-    dirty_branch_costs_match_template::<BLOSUM>(protein_alphabet());
+    dirty_branch_costs_match_template::<WAG>(Alphabet::protein());
+    dirty_branch_costs_match_template::<HIVB>(Alphabet::protein());
+    dirty_branch_costs_match_template::<BLOSUM>(Alphabet::protein());
 }
 
 #[cfg(test)]
@@ -985,10 +983,10 @@ fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet:
 #[test]
 fn modify_model_params_costs_match() {
     // does not apply to JC69, WAG, HIVB, BLOSUM which have no params
-    modify_model_params_costs_match_template::<K80>(dna_alphabet());
-    modify_model_params_costs_match_template::<HKY>(dna_alphabet());
-    modify_model_params_costs_match_template::<TN93>(dna_alphabet());
-    modify_model_params_costs_match_template::<GTR>(dna_alphabet());
+    modify_model_params_costs_match_template::<K80>(Alphabet::dna());
+    modify_model_params_costs_match_template::<HKY>(Alphabet::dna());
+    modify_model_params_costs_match_template::<TN93>(Alphabet::dna());
+    modify_model_params_costs_match_template::<GTR>(Alphabet::dna());
 }
 
 #[cfg(test)]
@@ -1021,12 +1019,12 @@ fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
 fn modify_model_freqs_costs_match() {
     // does not apply to JC69 and K80 which have no freqs
     let new_dna_freqs = frequencies!(&[0.1, 0.1, 0.1, 0.7]);
-    modify_model_freqs_costs_match_template::<HKY>(dna_alphabet(), new_dna_freqs.clone());
-    modify_model_freqs_costs_match_template::<TN93>(dna_alphabet(), new_dna_freqs.clone());
-    modify_model_freqs_costs_match_template::<GTR>(dna_alphabet(), new_dna_freqs);
+    modify_model_freqs_costs_match_template::<HKY>(Alphabet::dna(), new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<TN93>(Alphabet::dna(), new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<GTR>(Alphabet::dna(), new_dna_freqs);
 
     let new_aa_freqs = frequencies!(&[0.05; 20]);
-    modify_model_freqs_costs_match_template::<WAG>(protein_alphabet(), new_aa_freqs.clone());
-    modify_model_freqs_costs_match_template::<BLOSUM>(protein_alphabet(), new_aa_freqs.clone());
-    modify_model_freqs_costs_match_template::<HIVB>(protein_alphabet(), new_aa_freqs);
+    modify_model_freqs_costs_match_template::<WAG>(Alphabet::protein(), new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<BLOSUM>(Alphabet::protein(), new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<HIVB>(Alphabet::protein(), new_aa_freqs);
 }

--- a/phylo/src/substitution_models/dna_models/mod.rs
+++ b/phylo/src/substitution_models/dna_models/mod.rs
@@ -5,7 +5,7 @@ use std::iter;
 use approx::relative_eq;
 use log::warn;
 
-use crate::alphabets::{dna_alphabet, Alphabet, NUCLEOTIDE_INDEX};
+use crate::alphabets::{Alphabet, NUCLEOTIDE_INDEX};
 use crate::frequencies;
 use crate::likelihood::{ParamRange, PARAM_RANGE_DUMMY, PARAM_RANGE_POSITIVE};
 use crate::substitution_models::{FreqVector, QMatrix, QMatrixMaker, SubstMatrix};
@@ -48,7 +48,7 @@ impl QMatrixMaker for JC69 {
         JC69 {
             freqs: frequencies!(&[1.0 / DNA_N as f64; DNA_N]),
             q,
-            alphabet: dna_alphabet(),
+            alphabet: Alphabet::dna(),
         }
     }
 }
@@ -114,7 +114,7 @@ impl QMatrixMaker for K80 {
             freqs: frequencies!(&[1.0 / DNA_N as f64; DNA_N]),
             q,
             kappa: vec![kappa],
-            alphabet: dna_alphabet(),
+            alphabet: Alphabet::dna(),
         }
     }
 }
@@ -210,7 +210,7 @@ impl QMatrixMaker for HKY {
             freqs,
             q,
             kappa: vec![kappa],
-            alphabet: dna_alphabet(),
+            alphabet: Alphabet::dna(),
         }
     }
 }
@@ -322,7 +322,7 @@ impl QMatrixMaker for TN93 {
             freqs,
             q,
             params,
-            alphabet: dna_alphabet(),
+            alphabet: Alphabet::dna(),
         }
     }
 }
@@ -437,7 +437,7 @@ impl QMatrixMaker for GTR {
             freqs,
             q,
             params,
-            alphabet: dna_alphabet(),
+            alphabet: Alphabet::dna(),
         }
     }
 }

--- a/phylo/src/substitution_models/dna_models/mod.rs
+++ b/phylo/src/substitution_models/dna_models/mod.rs
@@ -34,7 +34,6 @@ fn set_dna_freqs(freqs: FreqVector) -> FreqVector {
 pub struct JC69 {
     freqs: FreqVector,
     q: SubstMatrix,
-    alphabet: Alphabet,
 }
 
 impl QMatrixMaker for JC69 {
@@ -48,7 +47,6 @@ impl QMatrixMaker for JC69 {
         JC69 {
             freqs: frequencies!(&[1.0 / DNA_N as f64; DNA_N]),
             q,
-            alphabet: Alphabet::dna(),
         }
     }
 }
@@ -74,8 +72,8 @@ impl QMatrix for JC69 {
     fn n(&self) -> usize {
         DNA_N
     }
-    fn alphabet(&self) -> &Alphabet {
-        &self.alphabet
+    fn alphabet() -> &'static Alphabet {
+        Alphabet::dna()
     }
 }
 
@@ -90,7 +88,6 @@ pub struct K80 {
     freqs: FreqVector,
     q: SubstMatrix,
     kappa: Vec<f64>,
-    alphabet: Alphabet,
 }
 
 impl QMatrixMaker for K80 {
@@ -114,7 +111,6 @@ impl QMatrixMaker for K80 {
             freqs: frequencies!(&[1.0 / DNA_N as f64; DNA_N]),
             q,
             kappa: vec![kappa],
-            alphabet: Alphabet::dna(),
         }
     }
 }
@@ -143,8 +139,8 @@ impl QMatrix for K80 {
     fn n(&self) -> usize {
         DNA_N
     }
-    fn alphabet(&self) -> &Alphabet {
-        &self.alphabet
+    fn alphabet() -> &'static Alphabet {
+        Alphabet::dna()
     }
 }
 
@@ -184,7 +180,6 @@ pub struct HKY {
     freqs: FreqVector,
     q: SubstMatrix,
     kappa: Vec<f64>,
-    alphabet: Alphabet,
 }
 
 impl QMatrixMaker for HKY {
@@ -210,7 +205,6 @@ impl QMatrixMaker for HKY {
             freqs,
             q,
             kappa: vec![kappa],
-            alphabet: Alphabet::dna(),
         }
     }
 }
@@ -242,8 +236,8 @@ impl QMatrix for HKY {
     fn n(&self) -> usize {
         DNA_N
     }
-    fn alphabet(&self) -> &Alphabet {
-        &self.alphabet
+    fn alphabet() -> &'static Alphabet {
+        Alphabet::dna()
     }
 }
 
@@ -295,7 +289,6 @@ pub struct TN93 {
     freqs: FreqVector,
     pub(crate) q: SubstMatrix,
     params: Vec<f64>,
-    alphabet: Alphabet,
 }
 
 impl QMatrixMaker for TN93 {
@@ -318,12 +311,7 @@ impl QMatrixMaker for TN93 {
 
         let mut q = SubstMatrix::zeros(DNA_N, DNA_N);
         tn93_q(&mut q, &freqs, &params);
-        TN93 {
-            freqs,
-            q,
-            params,
-            alphabet: Alphabet::dna(),
-        }
+        TN93 { freqs, q, params }
     }
 }
 
@@ -354,8 +342,8 @@ impl QMatrix for TN93 {
     fn n(&self) -> usize {
         DNA_N
     }
-    fn alphabet(&self) -> &Alphabet {
-        &self.alphabet
+    fn alphabet() -> &'static Alphabet {
+        Alphabet::dna()
     }
 }
 
@@ -413,7 +401,6 @@ pub struct GTR {
     freqs: FreqVector,
     q: SubstMatrix,
     params: Vec<f64>,
-    alphabet: Alphabet,
 }
 
 impl QMatrixMaker for GTR {
@@ -433,12 +420,7 @@ impl QMatrixMaker for GTR {
         }
         let mut q = SubstMatrix::zeros(DNA_N, DNA_N);
         gtr_q(&mut q, &freqs, &params);
-        GTR {
-            freqs,
-            q,
-            params,
-            alphabet: Alphabet::dna(),
-        }
+        GTR { freqs, q, params }
     }
 }
 
@@ -469,8 +451,8 @@ impl QMatrix for GTR {
     fn n(&self) -> usize {
         DNA_N
     }
-    fn alphabet(&self) -> &Alphabet {
-        &self.alphabet
+    fn alphabet() -> &'static Alphabet {
+        Alphabet::dna()
     }
 }
 

--- a/phylo/src/substitution_models/mod.rs
+++ b/phylo/src/substitution_models/mod.rs
@@ -54,7 +54,7 @@ pub trait QMatrix: Debug + Clone + Display {
     fn freqs(&self) -> &FreqVector;
     fn set_freqs(&mut self, freqs: FreqVector);
     fn n(&self) -> usize;
-    fn alphabet(&self) -> &Alphabet;
+    fn alphabet() -> &'static Alphabet;
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -118,8 +118,8 @@ impl<Q: QMatrix> EvoModel for SubstModel<Q> {
         self.qmatrix.n()
     }
 
-    fn alphabet(&self) -> &Alphabet {
-        self.qmatrix.alphabet()
+    fn alphabet() -> &'static Alphabet {
+        Q::alphabet()
     }
 }
 
@@ -134,7 +134,7 @@ impl<Q: QMatrix, A: Alignment> SubstitutionCostBuilder<Q, A> {
     }
 
     pub fn build(self) -> Result<SubstitutionCost<Q, A>> {
-        if self.info.msa.alphabet() != self.model.alphabet() {
+        if self.info.msa.alphabet() != Q::alphabet() {
             bail!("Alphabet mismatch between model and alignment");
         }
 

--- a/phylo/src/substitution_models/mod.rs
+++ b/phylo/src/substitution_models/mod.rs
@@ -326,7 +326,7 @@ impl<Q: QMatrix> SubstModelInfo<Q> {
                 if let Some(c) = alignment_map[i] {
                     site_info.copy_from(info.msa.alphabet().char_encoding(seq[c]));
                 } else {
-                    site_info.copy_from(info.msa.alphabet().gap_encoding());
+                    site_info.copy_from(info.msa.alphabet().missing_char_encoding());
                 }
             }
             leaf_seq_info.insert(node.idx, leaf_seq_w_gaps);

--- a/phylo/src/substitution_models/protein_models/mod.rs
+++ b/phylo/src/substitution_models/protein_models/mod.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use approx::relative_eq;
 use log::warn;
 
-use crate::alphabets::{protein_alphabet, Alphabet, AMINOACID_INDEX};
+use crate::alphabets::{Alphabet, AMINOACID_INDEX};
 use crate::frequencies;
 use crate::likelihood::{ParamRange, PARAM_RANGE_DUMMY};
 use crate::substitution_models::{FreqVector, QMatrix, QMatrixMaker, SubstMatrix};
@@ -64,7 +64,7 @@ macro_rules! define_protein_model {
                     freqs,
                     q,
                     exchangeability,
-                    alphabet: protein_alphabet().clone(),
+                    alphabet: Alphabet::protein().clone(),
                 }
             }
         }

--- a/phylo/src/substitution_models/protein_models/mod.rs
+++ b/phylo/src/substitution_models/protein_models/mod.rs
@@ -48,7 +48,6 @@ macro_rules! define_protein_model {
             freqs: FreqVector,
             q: SubstMatrix,
             exchangeability: SubstMatrix,
-            alphabet: Alphabet,
         }
         impl QMatrixMaker for $name {
             fn create(freqs: &[f64], _: &[f64]) -> $name {
@@ -64,7 +63,6 @@ macro_rules! define_protein_model {
                     freqs,
                     q,
                     exchangeability,
-                    alphabet: Alphabet::protein().clone(),
                 }
             }
         }
@@ -99,8 +97,8 @@ macro_rules! define_protein_model {
             fn rate(&self, i: u8, j: u8) -> f64 {
                 self.q[(AMINOACID_INDEX[i as usize], AMINOACID_INDEX[j as usize])]
             }
-            fn alphabet(&self) -> &Alphabet {
-                &self.alphabet
+            fn alphabet() -> &'static Alphabet {
+                Alphabet::protein()
             }
         }
 

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -789,7 +789,7 @@ fn protein_example_likelihood() {
 }
 
 #[cfg(test)]
-fn simple_reroot_info(alphabet: &Alphabet) -> (PhyloInfo<MSA>, PhyloInfo<MSA>) {
+fn simple_reroot_info(alphabet: &'static Alphabet) -> (PhyloInfo<MSA>, PhyloInfo<MSA>) {
     let tree = tree!("((A:2.0,B:2.0):1.0,C:2.0):0.0;");
     let seqs = Sequences::with_alphabet(
         vec![
@@ -797,7 +797,7 @@ fn simple_reroot_info(alphabet: &Alphabet) -> (PhyloInfo<MSA>, PhyloInfo<MSA>) {
             record!("B", b"ATATATATAAIHL"),
             record!("C", b"TTATATATATIJL"),
         ],
-        *alphabet,
+        alphabet,
     );
 
     let info = PhyloInfo {
@@ -816,7 +816,7 @@ fn simple_reroot_info(alphabet: &Alphabet) -> (PhyloInfo<MSA>, PhyloInfo<MSA>) {
 #[cfg(test)]
 fn logl_revers_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f64], epsilon: f64) {
     let model = SubstModel::<Q>::new(freqs, params);
-    let (info, info_rerooted) = simple_reroot_info(model.qmatrix.alphabet());
+    let (info, info_rerooted) = simple_reroot_info(Q::alphabet());
 
     let c = SCB::new(model.clone(), info).build().unwrap();
     let c_rerooted = SCB::new(model, info_rerooted).build().unwrap();
@@ -928,7 +928,7 @@ fn one_site_one_char_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: 
             record!("three", b"-"),
             record!("four", b"-"),
         ],
-        *model.qmatrix.alphabet(),
+        Q::alphabet(),
     );
     let tree = tree!("((one:2,two:2):1,(three:1,four:1):2);");
     let info = PhyloInfo {
@@ -1103,7 +1103,7 @@ fn x_fully_likely_template<Q: QMatrix + QMatrixMaker>(freqs: &[f64], params: &[f
             record!("C", b"X"),
             record!("D", b"X"),
         ],
-        *model.alphabet(),
+        Q::alphabet(),
     );
     let info = PhyloInfo {
         msa: MSA::from_aligned(seqs, &tree).unwrap(),
@@ -1233,7 +1233,7 @@ fn dna_zero_diag_scores() {
 }
 
 #[cfg(test)]
-fn setup_test_info(alphabet: Alphabet) -> PhyloInfo<MSA> {
+fn setup_test_info(alphabet: &'static Alphabet) -> PhyloInfo<MSA> {
     let tree = tree!("(((A:1.0,B:1.0)E:2.0,(C:1.0,D:1.0)F:2.0)G:3.0);");
     let msa = MSA::from_aligned(
         Sequences::with_alphabet(
@@ -1252,7 +1252,7 @@ fn setup_test_info(alphabet: Alphabet) -> PhyloInfo<MSA> {
 }
 
 #[cfg(test)]
-fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static Alphabet) {
     use crate::likelihood::TreeSearchCost;
 
     let info = setup_test_info(alphabet);
@@ -1289,7 +1289,7 @@ fn dirty_tree_costs_match() {
 }
 
 #[cfg(test)]
-fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static Alphabet) {
     use crate::likelihood::TreeSearchCost;
 
     let info = setup_test_info(alphabet);
@@ -1334,7 +1334,9 @@ fn dirty_branch_costs_match() {
 }
 
 #[cfg(test)]
-fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
+    alphabet: &'static Alphabet,
+) {
     let info = setup_test_info(alphabet);
 
     let model = SubstModel::<Q>::new(&[], &[1.0]);
@@ -1367,7 +1369,7 @@ fn modify_model_params_costs_match() {
 
 #[cfg(test)]
 fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
-    alphabet: Alphabet,
+    alphabet: &'static Alphabet,
     freqs: FreqVector,
 ) {
     let info = setup_test_info(alphabet);

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -7,7 +7,7 @@ use nalgebra::dvector;
 use rand::{rng, Rng};
 
 use crate::alignment::{Alignment, Sequences, MSA};
-use crate::alphabets::{dna_alphabet, protein_alphabet, Alphabet, AMINOACIDS, GAP};
+use crate::alphabets::{Alphabet, AMINOACIDS, GAP};
 use crate::evolutionary_models::EvoModel;
 use crate::io::read_sequences;
 use crate::likelihood::ModelSearchCost;
@@ -1277,15 +1277,15 @@ fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet
 
 #[test]
 fn dirty_tree_costs_match() {
-    dirty_tree_costs_match_template::<JC69>(dna_alphabet());
-    dirty_tree_costs_match_template::<K80>(dna_alphabet());
-    dirty_tree_costs_match_template::<HKY>(dna_alphabet());
-    dirty_tree_costs_match_template::<TN93>(dna_alphabet());
-    dirty_tree_costs_match_template::<GTR>(dna_alphabet());
+    dirty_tree_costs_match_template::<JC69>(Alphabet::dna());
+    dirty_tree_costs_match_template::<K80>(Alphabet::dna());
+    dirty_tree_costs_match_template::<HKY>(Alphabet::dna());
+    dirty_tree_costs_match_template::<TN93>(Alphabet::dna());
+    dirty_tree_costs_match_template::<GTR>(Alphabet::dna());
 
-    dirty_tree_costs_match_template::<WAG>(protein_alphabet());
-    dirty_tree_costs_match_template::<HIVB>(protein_alphabet());
-    dirty_tree_costs_match_template::<BLOSUM>(protein_alphabet());
+    dirty_tree_costs_match_template::<WAG>(Alphabet::protein());
+    dirty_tree_costs_match_template::<HIVB>(Alphabet::protein());
+    dirty_tree_costs_match_template::<BLOSUM>(Alphabet::protein());
 }
 
 #[cfg(test)]
@@ -1322,15 +1322,15 @@ fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphab
 
 #[test]
 fn dirty_branch_costs_match() {
-    dirty_branch_costs_match_template::<JC69>(dna_alphabet());
-    dirty_branch_costs_match_template::<K80>(dna_alphabet());
-    dirty_branch_costs_match_template::<HKY>(dna_alphabet());
-    dirty_branch_costs_match_template::<TN93>(dna_alphabet());
-    dirty_branch_costs_match_template::<GTR>(dna_alphabet());
+    dirty_branch_costs_match_template::<JC69>(Alphabet::dna());
+    dirty_branch_costs_match_template::<K80>(Alphabet::dna());
+    dirty_branch_costs_match_template::<HKY>(Alphabet::dna());
+    dirty_branch_costs_match_template::<TN93>(Alphabet::dna());
+    dirty_branch_costs_match_template::<GTR>(Alphabet::dna());
 
-    dirty_branch_costs_match_template::<WAG>(protein_alphabet());
-    dirty_branch_costs_match_template::<HIVB>(protein_alphabet());
-    dirty_branch_costs_match_template::<BLOSUM>(protein_alphabet());
+    dirty_branch_costs_match_template::<WAG>(Alphabet::protein());
+    dirty_branch_costs_match_template::<HIVB>(Alphabet::protein());
+    dirty_branch_costs_match_template::<BLOSUM>(Alphabet::protein());
 }
 
 #[cfg(test)]
@@ -1359,10 +1359,10 @@ fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet:
 #[test]
 fn modify_model_params_costs_match() {
     // does not apply to JC69, WAG, HIVB, BLOSUM which have no params
-    modify_model_params_costs_match_template::<K80>(dna_alphabet());
-    modify_model_params_costs_match_template::<HKY>(dna_alphabet());
-    modify_model_params_costs_match_template::<TN93>(dna_alphabet());
-    modify_model_params_costs_match_template::<GTR>(dna_alphabet());
+    modify_model_params_costs_match_template::<K80>(Alphabet::dna());
+    modify_model_params_costs_match_template::<HKY>(Alphabet::dna());
+    modify_model_params_costs_match_template::<TN93>(Alphabet::dna());
+    modify_model_params_costs_match_template::<GTR>(Alphabet::dna());
 }
 
 #[cfg(test)]
@@ -1395,12 +1395,12 @@ fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
 fn modify_model_freqs_costs_match() {
     // does not apply to JC69 and K80 which have no freqs
     let new_dna_freqs = frequencies!(&[0.1, 0.1, 0.1, 0.7]);
-    modify_model_freqs_costs_match_template::<HKY>(dna_alphabet(), new_dna_freqs.clone());
-    modify_model_freqs_costs_match_template::<TN93>(dna_alphabet(), new_dna_freqs.clone());
-    modify_model_freqs_costs_match_template::<GTR>(dna_alphabet(), new_dna_freqs);
+    modify_model_freqs_costs_match_template::<HKY>(Alphabet::dna(), new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<TN93>(Alphabet::dna(), new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<GTR>(Alphabet::dna(), new_dna_freqs);
 
     let new_aa_freqs = frequencies!(&[0.05; 20]);
-    modify_model_freqs_costs_match_template::<WAG>(protein_alphabet(), new_aa_freqs.clone());
-    modify_model_freqs_costs_match_template::<BLOSUM>(protein_alphabet(), new_aa_freqs.clone());
-    modify_model_freqs_costs_match_template::<HIVB>(protein_alphabet(), new_aa_freqs);
+    modify_model_freqs_costs_match_template::<WAG>(Alphabet::protein(), new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<BLOSUM>(Alphabet::protein(), new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<HIVB>(Alphabet::protein(), new_aa_freqs);
 }

--- a/phylo/src/substitution_models/tests.rs
+++ b/phylo/src/substitution_models/tests.rs
@@ -1252,10 +1252,10 @@ fn setup_test_info(alphabet: &'static Alphabet) -> PhyloInfo<MSA> {
 }
 
 #[cfg(test)]
-fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static Alphabet) {
+fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>() {
     use crate::likelihood::TreeSearchCost;
 
-    let info = setup_test_info(alphabet);
+    let info = setup_test_info(Q::alphabet());
 
     let model = SubstModel::<Q>::new(&[], &[]);
     let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
@@ -1277,22 +1277,22 @@ fn dirty_tree_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static
 
 #[test]
 fn dirty_tree_costs_match() {
-    dirty_tree_costs_match_template::<JC69>(Alphabet::dna());
-    dirty_tree_costs_match_template::<K80>(Alphabet::dna());
-    dirty_tree_costs_match_template::<HKY>(Alphabet::dna());
-    dirty_tree_costs_match_template::<TN93>(Alphabet::dna());
-    dirty_tree_costs_match_template::<GTR>(Alphabet::dna());
+    dirty_tree_costs_match_template::<JC69>();
+    dirty_tree_costs_match_template::<K80>();
+    dirty_tree_costs_match_template::<HKY>();
+    dirty_tree_costs_match_template::<TN93>();
+    dirty_tree_costs_match_template::<GTR>();
 
-    dirty_tree_costs_match_template::<WAG>(Alphabet::protein());
-    dirty_tree_costs_match_template::<HIVB>(Alphabet::protein());
-    dirty_tree_costs_match_template::<BLOSUM>(Alphabet::protein());
+    dirty_tree_costs_match_template::<WAG>();
+    dirty_tree_costs_match_template::<HIVB>();
+    dirty_tree_costs_match_template::<BLOSUM>();
 }
 
 #[cfg(test)]
-fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'static Alphabet) {
+fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>() {
     use crate::likelihood::TreeSearchCost;
 
-    let info = setup_test_info(alphabet);
+    let info = setup_test_info(Q::alphabet());
 
     let model = SubstModel::<Q>::new(&[], &[]);
     let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
@@ -1322,22 +1322,20 @@ fn dirty_branch_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: &'stat
 
 #[test]
 fn dirty_branch_costs_match() {
-    dirty_branch_costs_match_template::<JC69>(Alphabet::dna());
-    dirty_branch_costs_match_template::<K80>(Alphabet::dna());
-    dirty_branch_costs_match_template::<HKY>(Alphabet::dna());
-    dirty_branch_costs_match_template::<TN93>(Alphabet::dna());
-    dirty_branch_costs_match_template::<GTR>(Alphabet::dna());
+    dirty_branch_costs_match_template::<JC69>();
+    dirty_branch_costs_match_template::<K80>();
+    dirty_branch_costs_match_template::<HKY>();
+    dirty_branch_costs_match_template::<TN93>();
+    dirty_branch_costs_match_template::<GTR>();
 
-    dirty_branch_costs_match_template::<WAG>(Alphabet::protein());
-    dirty_branch_costs_match_template::<HIVB>(Alphabet::protein());
-    dirty_branch_costs_match_template::<BLOSUM>(Alphabet::protein());
+    dirty_branch_costs_match_template::<WAG>();
+    dirty_branch_costs_match_template::<HIVB>();
+    dirty_branch_costs_match_template::<BLOSUM>();
 }
 
 #[cfg(test)]
-fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
-    alphabet: &'static Alphabet,
-) {
-    let info = setup_test_info(alphabet);
+fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>() {
+    let info = setup_test_info(Q::alphabet());
 
     let model = SubstModel::<Q>::new(&[], &[1.0]);
     let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
@@ -1361,18 +1359,15 @@ fn modify_model_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
 #[test]
 fn modify_model_params_costs_match() {
     // does not apply to JC69, WAG, HIVB, BLOSUM which have no params
-    modify_model_params_costs_match_template::<K80>(Alphabet::dna());
-    modify_model_params_costs_match_template::<HKY>(Alphabet::dna());
-    modify_model_params_costs_match_template::<TN93>(Alphabet::dna());
-    modify_model_params_costs_match_template::<GTR>(Alphabet::dna());
+    modify_model_params_costs_match_template::<K80>();
+    modify_model_params_costs_match_template::<HKY>();
+    modify_model_params_costs_match_template::<TN93>();
+    modify_model_params_costs_match_template::<GTR>();
 }
 
 #[cfg(test)]
-fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
-    alphabet: &'static Alphabet,
-    freqs: FreqVector,
-) {
-    let info = setup_test_info(alphabet);
+fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(freqs: FreqVector) {
+    let info = setup_test_info(Q::alphabet());
 
     let model = SubstModel::<Q>::new(&[], &[]);
     let mut c = SCB::new(model.clone(), info.clone()).build().unwrap();
@@ -1397,12 +1392,12 @@ fn modify_model_freqs_costs_match_template<Q: QMatrix + QMatrixMaker>(
 fn modify_model_freqs_costs_match() {
     // does not apply to JC69 and K80 which have no freqs
     let new_dna_freqs = frequencies!(&[0.1, 0.1, 0.1, 0.7]);
-    modify_model_freqs_costs_match_template::<HKY>(Alphabet::dna(), new_dna_freqs.clone());
-    modify_model_freqs_costs_match_template::<TN93>(Alphabet::dna(), new_dna_freqs.clone());
-    modify_model_freqs_costs_match_template::<GTR>(Alphabet::dna(), new_dna_freqs);
+    modify_model_freqs_costs_match_template::<HKY>(new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<TN93>(new_dna_freqs.clone());
+    modify_model_freqs_costs_match_template::<GTR>(new_dna_freqs);
 
     let new_aa_freqs = frequencies!(&[0.05; 20]);
-    modify_model_freqs_costs_match_template::<WAG>(Alphabet::protein(), new_aa_freqs.clone());
-    modify_model_freqs_costs_match_template::<BLOSUM>(Alphabet::protein(), new_aa_freqs.clone());
-    modify_model_freqs_costs_match_template::<HIVB>(Alphabet::protein(), new_aa_freqs);
+    modify_model_freqs_costs_match_template::<WAG>(new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<BLOSUM>(new_aa_freqs.clone());
+    modify_model_freqs_costs_match_template::<HIVB>(new_aa_freqs);
 }

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -778,10 +778,8 @@ fn tkf_indel_history_doesnt_change_felsenstein() {
 }
 
 #[cfg(test)]
-fn modify_tkf92_subst_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
-    alphabet: &'static Alphabet,
-) {
-    let phylo = setup_test_phylo(alphabet);
+fn modify_tkf92_subst_params_costs_match_template<Q: QMatrix + QMatrixMaker>() {
+    let phylo = setup_test_phylo(Q::alphabet());
     let subst_original_param = 1.0;
     let subst_changed_param = 0.5;
     let subst_model = SubstModel::<Q>::new(&[], &[subst_original_param]);
@@ -810,10 +808,8 @@ fn modify_tkf92_subst_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
 }
 
 #[cfg(test)]
-fn modify_tkf92_indel_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
-    alphabet: &'static Alphabet,
-) {
-    let phylo = setup_test_phylo(alphabet);
+fn modify_tkf92_indel_params_costs_match_template<Q: QMatrix + QMatrixMaker>() {
+    let phylo = setup_test_phylo(Q::alphabet());
     let subst_model = SubstModel::<Q>::new(&[], &[]);
     let tkf_original_mu = 0.2;
     let tkf_changed_mu = 0.25;
@@ -843,20 +839,20 @@ fn modify_tkf92_indel_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
 
 #[test]
 fn tkf92_modify_subst_model_params_costs_match() {
-    modify_tkf92_subst_params_costs_match_template::<K80>(Alphabet::dna());
-    modify_tkf92_subst_params_costs_match_template::<HKY>(Alphabet::dna());
-    modify_tkf92_subst_params_costs_match_template::<TN93>(Alphabet::dna());
-    modify_tkf92_subst_params_costs_match_template::<GTR>(Alphabet::dna());
+    modify_tkf92_subst_params_costs_match_template::<K80>();
+    modify_tkf92_subst_params_costs_match_template::<HKY>();
+    modify_tkf92_subst_params_costs_match_template::<TN93>();
+    modify_tkf92_subst_params_costs_match_template::<GTR>();
 }
 
 #[test]
 fn tkf_modify_indel_model_params_costs_match() {
-    modify_tkf92_indel_params_costs_match_template::<JC69>(Alphabet::dna());
-    modify_tkf92_indel_params_costs_match_template::<K80>(Alphabet::dna());
-    modify_tkf92_indel_params_costs_match_template::<HKY>(Alphabet::dna());
-    modify_tkf92_indel_params_costs_match_template::<TN93>(Alphabet::dna());
-    modify_tkf92_indel_params_costs_match_template::<GTR>(Alphabet::dna());
-    modify_tkf92_indel_params_costs_match_template::<WAG>(Alphabet::protein());
-    modify_tkf92_indel_params_costs_match_template::<BLOSUM>(Alphabet::protein());
-    modify_tkf92_indel_params_costs_match_template::<HIVB>(Alphabet::protein());
+    modify_tkf92_indel_params_costs_match_template::<JC69>();
+    modify_tkf92_indel_params_costs_match_template::<K80>();
+    modify_tkf92_indel_params_costs_match_template::<HKY>();
+    modify_tkf92_indel_params_costs_match_template::<TN93>();
+    modify_tkf92_indel_params_costs_match_template::<GTR>();
+    modify_tkf92_indel_params_costs_match_template::<WAG>();
+    modify_tkf92_indel_params_costs_match_template::<BLOSUM>();
+    modify_tkf92_indel_params_costs_match_template::<HIVB>();
 }

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -271,7 +271,7 @@ fn tkf92_get_blocks() {
 }
 
 #[cfg(test)]
-pub(super) fn setup_test_phylo(alphabet: Alphabet) -> PhyloInfo<MASA> {
+pub(super) fn setup_test_phylo(alphabet: &'static Alphabet) -> PhyloInfo<MASA> {
     let tree = tree!("(((A1:2.0,B2:2.0)I3:0.3,C4:2.0)R5:1.0);");
     let msa = MASA::from_aligned_with_ancestral(
         Sequences::with_alphabet(
@@ -778,7 +778,9 @@ fn tkf_indel_history_doesnt_change_felsenstein() {
 }
 
 #[cfg(test)]
-fn modify_tkf92_subst_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+fn modify_tkf92_subst_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
+    alphabet: &'static Alphabet,
+) {
     let phylo = setup_test_phylo(alphabet);
     let subst_original_param = 1.0;
     let subst_changed_param = 0.5;
@@ -808,7 +810,9 @@ fn modify_tkf92_subst_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alp
 }
 
 #[cfg(test)]
-fn modify_tkf92_indel_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alphabet: Alphabet) {
+fn modify_tkf92_indel_params_costs_match_template<Q: QMatrix + QMatrixMaker>(
+    alphabet: &'static Alphabet,
+) {
     let phylo = setup_test_phylo(alphabet);
     let subst_model = SubstModel::<Q>::new(&[], &[]);
     let tkf_original_mu = 0.2;

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -2,7 +2,7 @@ use approx::assert_relative_eq;
 use nalgebra::DVector;
 
 use crate::alignment::{Alignment, AncestralAlignment, Mapping, Sequences, MASA};
-use crate::alphabets::{dna_alphabet, protein_alphabet, Alphabet};
+use crate::alphabets::Alphabet;
 use crate::likelihood::{
     ModelSearchCost, PARAM_RANGE_POSITIVE, PARAM_RANGE_UNIT_INTERVAL_EXCLUSIVE,
 };
@@ -293,7 +293,7 @@ pub(super) fn setup_test_phylo(alphabet: Alphabet) -> PhyloInfo<MASA> {
 #[test]
 fn tkf_indel_get_and_set_params_and_freqs() {
     let mut tkf_indel_cost =
-        TKF92IndelCostBuilder::new(1.0, 2.0, 0.3, setup_test_phylo(dna_alphabet()))
+        TKF92IndelCostBuilder::new(1.0, 2.0, 0.3, setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
     // params
@@ -313,17 +313,22 @@ fn tkf_indel_get_and_set_params_and_freqs() {
     assert_eq!(tkf_indel_cost.freqs(), &*DUMMY_FREQS);
     assert_eq!(
         tkf_indel_cost.empirical_freqs(),
-        setup_test_phylo(dna_alphabet()).freqs()
+        setup_test_phylo(Alphabet::dna()).freqs()
     );
 }
 
 #[test]
 fn tkf_get_and_set_params() {
     let subst_model = SubstModel::<GTR>::new(&[0.1, 0.2, 0.3, 0.4], &[0.5, 0.6, 0.7, 0.8, 0.9]);
-    let mut tkf_cost =
-        TKF92CostBuilder::new(1.0, 2.0, 0.3, subst_model, setup_test_phylo(dna_alphabet()))
-            .build()
-            .unwrap();
+    let mut tkf_cost = TKF92CostBuilder::new(
+        1.0,
+        2.0,
+        0.3,
+        subst_model,
+        setup_test_phylo(Alphabet::dna()),
+    )
+    .build()
+    .unwrap();
     assert_eq!(tkf_cost.param_count(), 8);
     assert_eq!(tkf_cost.param(0), 1.0);
     assert_eq!(tkf_cost.param(1), 2.0);
@@ -350,13 +355,13 @@ fn tkf_get_and_set_params() {
 
     assert_eq!(
         tkf_cost.empirical_freqs(),
-        setup_test_phylo(dna_alphabet()).freqs()
+        setup_test_phylo(Alphabet::dna()).freqs()
     );
 }
 
 #[test]
 fn tkf91_indel_cost_fmt() {
-    let tkf_indel_cost = TKF91IndelCostBuilder::new(1.0, 2.0, setup_test_phylo(dna_alphabet()))
+    let tkf_indel_cost = TKF91IndelCostBuilder::new(1.0, 2.0, setup_test_phylo(Alphabet::dna()))
         .build()
         .unwrap();
 
@@ -368,7 +373,7 @@ fn tkf91_indel_cost_fmt() {
 #[test]
 fn tkf91_cost_fmt() {
     let subst_model = SubstModel::<JC69>::new(&[], &[]);
-    let tkf_cost = TKF91CostBuilder::new(1.0, 2.0, subst_model, setup_test_phylo(dna_alphabet()))
+    let tkf_cost = TKF91CostBuilder::new(1.0, 2.0, subst_model, setup_test_phylo(Alphabet::dna()))
         .build()
         .unwrap();
 
@@ -380,7 +385,7 @@ fn tkf91_cost_fmt() {
 #[test]
 fn tkf92_indel_cost_fmt() {
     let tkf_indel_cost =
-        TKF92IndelCostBuilder::new(1.0, 2.0, 0.3, setup_test_phylo(dna_alphabet()))
+        TKF92IndelCostBuilder::new(1.0, 2.0, 0.3, setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
 
@@ -392,10 +397,15 @@ fn tkf92_indel_cost_fmt() {
 #[test]
 fn tkf92_cost_fmt() {
     let subst_model = SubstModel::<JC69>::new(&[], &[]);
-    let tkf_cost =
-        TKF92CostBuilder::new(1.0, 2.0, 0.3, subst_model, setup_test_phylo(dna_alphabet()))
-            .build()
-            .unwrap();
+    let tkf_cost = TKF92CostBuilder::new(
+        1.0,
+        2.0,
+        0.3,
+        subst_model,
+        setup_test_phylo(Alphabet::dna()),
+    )
+    .build()
+    .unwrap();
 
     let fmt = format!("{}", tkf_cost);
 
@@ -405,10 +415,15 @@ fn tkf92_cost_fmt() {
 #[test]
 fn tkf_get_and_set_freqs() {
     let subst_model = SubstModel::<GTR>::new(&[0.1, 0.2, 0.3, 0.4], &[0.5, 0.6, 0.7, 0.8, 0.9]);
-    let mut tkf_cost =
-        TKF92CostBuilder::new(1.0, 2.0, 0.3, subst_model, setup_test_phylo(dna_alphabet()))
-            .build()
-            .unwrap();
+    let mut tkf_cost = TKF92CostBuilder::new(
+        1.0,
+        2.0,
+        0.3,
+        subst_model,
+        setup_test_phylo(Alphabet::dna()),
+    )
+    .build()
+    .unwrap();
     assert_eq!(tkf_cost.freqs().as_slice(), &[0.1, 0.2, 0.3, 0.4]);
     tkf_cost.set_freqs(frequencies!(&[0.4, 0.3, 0.2, 0.1]));
     assert_eq!(tkf_cost.freqs().as_slice(), &[0.4, 0.3, 0.2, 0.1]);
@@ -417,7 +432,7 @@ fn tkf_get_and_set_freqs() {
 #[test]
 fn tkf91_param_range() {
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
-    let tkf_cost = TKF91CostBuilder::new(1.0, 2.0, subst_model, setup_test_phylo(dna_alphabet()))
+    let tkf_cost = TKF91CostBuilder::new(1.0, 2.0, subst_model, setup_test_phylo(Alphabet::dna()))
         .build()
         .unwrap();
     let lambda_range = tkf_cost.param_range(usize::from(TKF92Parameters::Lambda));
@@ -437,10 +452,15 @@ fn tkf91_param_range() {
 #[test]
 fn tkf92_param_range() {
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
-    let tkf_cost =
-        TKF92CostBuilder::new(1.0, 2.0, 0.3, subst_model, setup_test_phylo(dna_alphabet()))
-            .build()
-            .unwrap();
+    let tkf_cost = TKF92CostBuilder::new(
+        1.0,
+        2.0,
+        0.3,
+        subst_model,
+        setup_test_phylo(Alphabet::dna()),
+    )
+    .build()
+    .unwrap();
     let lambda_range = tkf_cost.param_range(usize::from(TKF92Parameters::Lambda));
     let true_lambda_range = (f64::EPSILON, 2.0 - f64::EPSILON);
     assert_eq!(lambda_range, true_lambda_range);
@@ -617,7 +637,7 @@ fn tkf92_indel_logl() {
 
 #[test]
 fn tkf91_cost_builder_fails() {
-    let phylo = setup_test_phylo(protein_alphabet());
+    let phylo = setup_test_phylo(Alphabet::protein());
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
 
     let tkf91_err_msg = TKF91CostBuilder::new(0.1, 0.2, subst_model, phylo)
@@ -633,7 +653,7 @@ fn tkf91_cost_builder_fails() {
 
 #[test]
 fn tkf92_cost_builder_fails() {
-    let phylo = setup_test_phylo(protein_alphabet());
+    let phylo = setup_test_phylo(Alphabet::protein());
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
 
     let tkf92_err_msg = TKF92CostBuilder::new(0.1, 0.2, 0.3, subst_model, phylo)
@@ -650,7 +670,7 @@ fn tkf92_cost_builder_fails() {
 #[test]
 fn tkf91_logl_with_substitution() {
     // arrange
-    let phylo = setup_test_phylo(dna_alphabet());
+    let phylo = setup_test_phylo(Alphabet::dna());
     let subst_model = SubstModel::<GTR>::new(&[0.1, 0.3, 0.4, 0.2], &[1.2, 0.5, 5.0, 1.0, 1.0]);
     let subst_cost = SCB::new(subst_model.clone(), phylo.clone())
         .build()
@@ -676,7 +696,7 @@ fn tkf91_logl_with_substitution() {
 #[test]
 fn tkf92_logl_with_substitution() {
     // arrange
-    let phylo = setup_test_phylo(dna_alphabet());
+    let phylo = setup_test_phylo(Alphabet::dna());
     let subst_model = SubstModel::<GTR>::new(&[0.1, 0.3, 0.4, 0.2], &[1.2, 0.5, 5.0, 1.0, 1.0]);
     let subst_cost = SCB::new(subst_model.clone(), phylo.clone())
         .build()
@@ -819,20 +839,20 @@ fn modify_tkf92_indel_params_costs_match_template<Q: QMatrix + QMatrixMaker>(alp
 
 #[test]
 fn tkf92_modify_subst_model_params_costs_match() {
-    modify_tkf92_subst_params_costs_match_template::<K80>(dna_alphabet());
-    modify_tkf92_subst_params_costs_match_template::<HKY>(dna_alphabet());
-    modify_tkf92_subst_params_costs_match_template::<TN93>(dna_alphabet());
-    modify_tkf92_subst_params_costs_match_template::<GTR>(dna_alphabet());
+    modify_tkf92_subst_params_costs_match_template::<K80>(Alphabet::dna());
+    modify_tkf92_subst_params_costs_match_template::<HKY>(Alphabet::dna());
+    modify_tkf92_subst_params_costs_match_template::<TN93>(Alphabet::dna());
+    modify_tkf92_subst_params_costs_match_template::<GTR>(Alphabet::dna());
 }
 
 #[test]
 fn tkf_modify_indel_model_params_costs_match() {
-    modify_tkf92_indel_params_costs_match_template::<JC69>(dna_alphabet());
-    modify_tkf92_indel_params_costs_match_template::<K80>(dna_alphabet());
-    modify_tkf92_indel_params_costs_match_template::<HKY>(dna_alphabet());
-    modify_tkf92_indel_params_costs_match_template::<TN93>(dna_alphabet());
-    modify_tkf92_indel_params_costs_match_template::<GTR>(dna_alphabet());
-    modify_tkf92_indel_params_costs_match_template::<WAG>(protein_alphabet());
-    modify_tkf92_indel_params_costs_match_template::<BLOSUM>(protein_alphabet());
-    modify_tkf92_indel_params_costs_match_template::<HIVB>(protein_alphabet());
+    modify_tkf92_indel_params_costs_match_template::<JC69>(Alphabet::dna());
+    modify_tkf92_indel_params_costs_match_template::<K80>(Alphabet::dna());
+    modify_tkf92_indel_params_costs_match_template::<HKY>(Alphabet::dna());
+    modify_tkf92_indel_params_costs_match_template::<TN93>(Alphabet::dna());
+    modify_tkf92_indel_params_costs_match_template::<GTR>(Alphabet::dna());
+    modify_tkf92_indel_params_costs_match_template::<WAG>(Alphabet::protein());
+    modify_tkf92_indel_params_costs_match_template::<BLOSUM>(Alphabet::protein());
+    modify_tkf92_indel_params_costs_match_template::<HIVB>(Alphabet::protein());
 }

--- a/phylo/src/tkf_model/tkf91.rs
+++ b/phylo/src/tkf_model/tkf91.rs
@@ -6,7 +6,6 @@ use log::warn;
 use num_enum::{FromPrimitive, IntoPrimitive};
 
 use crate::alignment::AncestralAlignment;
-use crate::evolutionary_models::EvoModel;
 use crate::likelihood::ParamRange;
 use crate::phylo_info::PhyloInfo;
 use crate::substitution_models::{QMatrix, SubstModel, SubstitutionCostBuilder as SCB};
@@ -160,7 +159,7 @@ impl<Q: QMatrix, AA: AncestralAlignment> TKF91CostBuilder<Q, AA> {
     }
 
     pub fn build(self) -> Result<TKFCost<Q, TKF91IndelModel, AA>> {
-        if self.phylo.msa.alphabet() != self.subst_model.alphabet() {
+        if self.phylo.msa.alphabet() != Q::alphabet() {
             bail!("Alphabet mismatch between model and alignment");
         }
 

--- a/phylo/src/tkf_model/tkf92.rs
+++ b/phylo/src/tkf_model/tkf92.rs
@@ -6,7 +6,6 @@ use hashbrown::HashSet;
 use log::warn;
 use num_enum::{FromPrimitive, IntoPrimitive};
 
-use crate::evolutionary_models::EvoModel;
 use crate::likelihood::{ParamRange, PARAM_RANGE_UNIT_INTERVAL_EXCLUSIVE};
 use crate::substitution_models::{QMatrix, SubstModel, SubstitutionCostBuilder as SCB};
 use crate::tkf_model::{
@@ -213,7 +212,7 @@ impl<Q: QMatrix, AA: AncestralAlignment> TKF92CostBuilder<Q, AA> {
     }
 
     pub fn build(self) -> Result<TKFCost<Q, TKF92IndelModel, AA>> {
-        if self.phylo.msa.alphabet() != self.subst_model.alphabet() {
+        if self.phylo.msa.alphabet() != Q::alphabet() {
             bail!("Alphabet mismatch between model and alignment");
         }
 

--- a/phylo/src/tkf_model/tkf_indel.rs
+++ b/phylo/src/tkf_model/tkf_indel.rs
@@ -474,7 +474,7 @@ pub(super) fn get_block_lengths(blocks: &[usize]) -> Vec<usize> {
 mod private_tests {
 
     use super::*;
-    use crate::alphabets::dna_alphabet;
+    use crate::alphabets::Alphabet;
     use crate::tkf_model::tests::setup_test_phylo;
     use crate::tkf_model::TKF91IndelCostBuilder;
     use crate::tkf_model::TKF92IndelCostBuilder;
@@ -482,12 +482,12 @@ mod private_tests {
 
     #[cfg(test)]
     fn validate_lambda_mu(l: f64, m: f64, l_expected: f64, m_expected: f64) {
-        let cost = TKF91IndelCostBuilder::new(l, m, setup_test_phylo(dna_alphabet()))
+        let cost = TKF91IndelCostBuilder::new(l, m, setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
         assert_eq!(cost.model.lambda(), l_expected);
         assert_eq!(cost.model.mu(), m_expected);
-        let cost = TKF92IndelCostBuilder::new(l, m, 0.1, setup_test_phylo(dna_alphabet()))
+        let cost = TKF92IndelCostBuilder::new(l, m, 0.1, setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
         assert_eq!(cost.model.lambda(), l_expected);
@@ -496,7 +496,7 @@ mod private_tests {
 
     #[cfg(test)]
     fn validate_r(r: f64, r_expected: f64) {
-        let cost = TKF92IndelCostBuilder::new(1.0, 2.0, r, setup_test_phylo(dna_alphabet()))
+        let cost = TKF92IndelCostBuilder::new(1.0, 2.0, r, setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
         assert_eq!(cost.model.r(), r_expected);


### PR DESCRIPTION
Refactor alphabets for clarity and fewer memory allocations (alphabets are now always represented as a reference to a static object). Added doctrings to `Alphabet` methods.