### PR TITLE
tree almost_eq

### DIFF
--- a/phylo/src/asr/tests.rs
+++ b/phylo/src/asr/tests.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 #[test]
-fn reconstruct_ancestral_seqs_n_seqs_not_same_as_leaves() {
+fn asr_n_seqs_not_same_as_leaves() {
     // arrange
     let tree = tree!("root:1.0;");
     let seqs = Sequences::new(vec![record!("root", Some("seq with 4 nucls"), b"AA--AAA")]);

--- a/phylo/src/optimisers/spr_optimiser.rs
+++ b/phylo/src/optimisers/spr_optimiser.rs
@@ -262,6 +262,25 @@ fn rooted_spr(tree: &Tree, prune_idx: &NodeIdx, regraft_idx: &NodeIdx) -> Result
     Ok(rooted_spr_unchecked(tree, prune_idx, regraft_idx))
 }
 
+/// ```text
+/// before:                       |
+///                     -----prune_grpar-----
+///                     |                   |
+///               --prune_par--       --regraft_par--
+///               |           |       |             |
+///          prune_sib      prune     .             --------
+///                                                        |
+///                                                      regraft
+///
+/// after:                        |
+///                     -----prune_grpar-----
+///                     |                   |
+///               -------             --regraft_par--
+///               |                   |             |
+///          prune_sib                .        --prune_par--
+///                                            |           |
+///                                          prune       regraft
+/// ```
 fn rooted_spr_unchecked(tree: &Tree, prune_idx: &NodeIdx, regraft_idx: &NodeIdx) -> Tree {
     let prune = tree.node(prune_idx);
     let prune_sib = tree.node(&tree.sibling(&prune.idx).unwrap());

--- a/phylo/src/optimisers/spr_optimiser.rs
+++ b/phylo/src/optimisers/spr_optimiser.rs
@@ -262,25 +262,6 @@ fn rooted_spr(tree: &Tree, prune_idx: &NodeIdx, regraft_idx: &NodeIdx) -> Result
     Ok(rooted_spr_unchecked(tree, prune_idx, regraft_idx))
 }
 
-/// ```text
-/// before:                       |
-///                     -----prune_grpar-----
-///                     |                   |
-///               --prune_par--       --regraft_par--
-///               |           |       |             |
-///          prune_sib      prune     .             --------
-///                                                        |
-///                                                      regraft
-///
-/// after:                        |
-///                     -----prune_grpar-----
-///                     |                   |
-///               -------             --regraft_par--
-///               |                   |             |
-///          prune_sib                .        --prune_par--
-///                                            |           |
-///                                          prune       regraft
-/// ```
 fn rooted_spr_unchecked(tree: &Tree, prune_idx: &NodeIdx, regraft_idx: &NodeIdx) -> Tree {
     let prune = tree.node(prune_idx);
     let prune_sib = tree.node(&tree.sibling(&prune.idx).unwrap());

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -381,9 +381,9 @@ impl Tree {
     }
 
     /// Compares two trees for approximate equality, allowing for small differences in branch
-    /// lengths. Not caring about the order of nodes in the internal representation or correspondence
-    /// of [`Node`]s and [`NodeIdx`]s. The order of children of a node is ignored, i.e.,
-    /// they are compared as sets. Returning `false` in the case of `NaN` branch lengths.
+    /// lengths. This comparison does not care about the order of nodes in the internal representation
+    /// or correspondence of [`Node`]s and [`NodeIdx`]s. The order of children of a node is ignored,
+    /// i.e., they are compared as sets. It returns `false` in the case of `NaN` branch lengths.
     ///
     /// # Errors
     ///

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -434,7 +434,7 @@ impl Tree {
                 let n2 = match n2_option {
                     Some(n) => n,
                     None => {
-                        warn!("Lineage for leaf '{}' is shorther in other tree", leaf_id);
+                        warn!("Lineage for leaf '{}' is shorter in other tree", leaf_id);
                         return false;
                     }
                 };

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -385,7 +385,7 @@ impl Tree {
     /// or correspondence of [`Node`]s and [`NodeIdx`]s. The order of children of a node is ignored,
     /// i.e., they are compared as sets. It returns `false` in the case of `NaN` branch lengths.
     ///
-    /// # Errors
+    /// # Panics
     ///
     /// Panics if the ids of the leaves are not unique;
     pub fn almost_eq(&self, other: &Self, epsilon: f64) -> bool {

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -167,6 +167,10 @@ impl Tree {
         partitions
     }
 
+    /// Returns true if `query` is in the subtree rooted at `node`.
+    /// This assumes that the matching between [ids](`Node::id`) and [idx](`Node::idx`) is the
+    /// same in the two trees. That means even if [`Tree::almost_eq`] returns true, this method
+    /// here can return false if you pass the two roots.
     pub(crate) fn is_subtree(&self, query: &NodeIdx, node: &NodeIdx) -> bool {
         let order = self.preorder_subroot(node);
         order.contains(query)
@@ -375,6 +379,86 @@ impl Tree {
             }
         }
         Ok(())
+    }
+
+    /// Compares two trees for approximate equality, allowing for small differences in branch
+    /// lengths. The order of children of a node is ignored, i.e., they are compared as sets.
+    /// Returning false in the case of `NaN` branch lengths.
+    ///
+    /// # Errors
+    ///
+    /// Panics if the ids of the leaves are not unique;
+    pub fn almost_eq(&self, other: &Self, epsilon: f64) -> bool {
+        if self.n != self.leaf_ids.iter().collect::<HashSet<_>>().len() {
+            panic!("Self tree has non-unique leaf ids");
+        }
+        if other.n != other.leaf_ids.iter().collect::<HashSet<_>>().len() {
+            panic!("Other tree has non-unique leaf ids");
+        }
+
+        if self.length.is_nan()
+            || other.length.is_nan()
+            || (self.length - other.length).abs() > epsilon
+        {
+            println!("Total lengths differ");
+            return false;
+        }
+        if self.n != other.n
+            || self.complete != other.complete
+            || self.nodes.len() != other.nodes.len()
+        {
+            println!("Root, n, complete, nodes.len, preorder, or postorder differ");
+            return false;
+        }
+
+        for leaf_id in &self.leaf_ids {
+            let mut n1_option = self.nodes.iter().find(|node| node.id == *leaf_id);
+            let mut n2_option = other.nodes.iter().find(|node| node.id == *leaf_id);
+
+            if n1_option.is_none() || n2_option.is_none() {
+                println!("Leaf id {} not found in both trees", leaf_id);
+                return false;
+            }
+            while let Some(n1) = n1_option {
+                let n2 = match n2_option {
+                    Some(n) => n,
+                    None => {
+                        println!("Node id {} not found in both trees", n1.id);
+                        return false;
+                    }
+                };
+                // checking the ids
+                if n1.id != n2.id {
+                    println!("Node ids differ: {} vs {}", n1.id, n2.id);
+                    return false;
+                }
+                // checking the branch lengths
+                if n1.blen.is_nan() || n2.blen.is_nan() || (n1.blen - n2.blen).abs() > epsilon {
+                    println!(
+                        "Branch lengths differ for node {}: {} vs {}",
+                        n1.id, n1.blen, n2.blen
+                    );
+                    return false;
+                }
+                // continue with the parents
+                n1_option = match n1.parent {
+                    Some(parent_idx) => Some(self.node(&parent_idx)),
+                    None => None,
+                };
+                n2_option = match n2.parent {
+                    Some(parent_idx) => Some(other.node(&parent_idx)),
+                    None => None,
+                };
+            }
+            // checking if n2_option is None as well
+            if n2_option.is_some() {
+                println!("Trees differ in structure above leaf id {}", leaf_id);
+                return false;
+            }
+        }
+
+        // not comparing Tree.dirty as it is crate internal
+        true
     }
 }
 

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::{Debug, Display};
 use anyhow::bail;
 use fixedbitset::FixedBitSet;
 use inc_stats::Percentiles;
+use log::warn;
 
 use crate::alignment::Sequences;
 use crate::parsimony::Rounding;
@@ -66,6 +67,7 @@ pub struct Tree {
     postorder: Vec<NodeIdx>,
     preorder: Vec<NodeIdx>,
     leaf_ids: Vec<String>,
+    // TODO: what is meant by this?
     pub complete: bool,
     /// The number of leaves in the tree.
     pub n: usize,
@@ -168,9 +170,6 @@ impl Tree {
     }
 
     /// Returns true if `query` is in the subtree rooted at `node`.
-    /// This assumes that the matching between [ids](`Node::id`) and [idx](`Node::idx`) is the
-    /// same in the two trees. That means even if [`Tree::almost_eq`] returns true, this method
-    /// here can return false if you pass the two roots.
     pub(crate) fn is_subtree(&self, query: &NodeIdx, node: &NodeIdx) -> bool {
         let order = self.preorder_subroot(node);
         order.contains(query)
@@ -382,8 +381,9 @@ impl Tree {
     }
 
     /// Compares two trees for approximate equality, allowing for small differences in branch
-    /// lengths. The order of children of a node is ignored, i.e., they are compared as sets.
-    /// Returning false in the case of `NaN` branch lengths.
+    /// lengths. Not caring about the order of nodes in the internal representation or correspondence
+    /// of [`Node`]s and [`NodeIdx`]s. The order of children of a node is ignored, i.e.,
+    /// they are compared as sets. Returning `false` in the case of `NaN` branch lengths.
     ///
     /// # Errors
     ///
@@ -400,43 +400,57 @@ impl Tree {
             || other.length.is_nan()
             || (self.length - other.length).abs() > epsilon
         {
-            println!("Total lengths differ");
+            warn!("Tree lengths differ: {} vs {}", self.length, other.length);
             return false;
         }
         if self.n != other.n
             || self.complete != other.complete
             || self.nodes.len() != other.nodes.len()
         {
-            println!("Root, n, complete, nodes.len, preorder, or postorder differ");
+            warn!(
+                "Tree structures differ: n (= number of leaves): {} vs {}, complete: {} vs {}, number of nodes: {} vs {}",
+                self.n,
+                other.n,
+                self.complete,
+                other.complete,
+                self.nodes.len(),
+                other.nodes.len()
+            );
             return false;
         }
 
+        // For each leaf, traverse up to the root and compare the nodes along the way
         for leaf_id in &self.leaf_ids {
+            // this is never None
             let mut n1_option = self.nodes.iter().find(|node| node.id == *leaf_id);
+            // this might be None
             let mut n2_option = other.nodes.iter().find(|node| node.id == *leaf_id);
 
-            if n1_option.is_none() || n2_option.is_none() {
-                println!("Leaf id {} not found in both trees", leaf_id);
+            if n2_option.is_none() {
+                warn!("Leaf id '{}' not found in other tree", leaf_id);
                 return false;
             }
             while let Some(n1) = n1_option {
                 let n2 = match n2_option {
                     Some(n) => n,
                     None => {
-                        println!("Node id {} not found in both trees", n1.id);
+                        warn!("Lineage for leaf '{}' is shorther in other tree", leaf_id);
                         return false;
                     }
                 };
                 // checking the ids
                 if n1.id != n2.id {
-                    println!("Node ids differ: {} vs {}", n1.id, n2.id);
+                    warn!(
+                        "Node ids differ: '{}' vs '{}', in the lineage for leaf '{}'",
+                        n1.id, n2.id, leaf_id
+                    );
                     return false;
                 }
                 // checking the branch lengths
                 if n1.blen.is_nan() || n2.blen.is_nan() || (n1.blen - n2.blen).abs() > epsilon {
-                    println!(
-                        "Branch lengths differ for node {}: {} vs {}",
-                        n1.id, n1.blen, n2.blen
+                    warn!(
+                        "Branch lengths differ for node '{}': {} vs {}, in the lineage for leaf '{}'",
+                        n1.id, n1.blen, n2.blen, leaf_id
                     );
                     return false;
                 }
@@ -450,9 +464,8 @@ impl Tree {
                     None => None,
                 };
             }
-            // checking if n2_option is None as well
             if n2_option.is_some() {
-                println!("Trees differ in structure above leaf id {}", leaf_id);
+                warn!("Lineage for leaf id '{}' is longer in other tree", leaf_id);
                 return false;
             }
         }

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -299,6 +299,8 @@ fn newick_parse_whitespace() {
     let tree0 = &trees.unwrap()[0];
     let tree1 = &from_newick("(((((A:1,B:1)F:1,C:2)G:1,D:3)H:1,E:4)I:1);").unwrap()[0];
     assert_eq!(tree0.nodes, tree1.nodes);
+    let epsilon = 0.0;
+    assert!(tree0.almost_eq(tree1, epsilon))
 }
 
 #[test]
@@ -739,3 +741,96 @@ fn rf_distance_against_raxml() {
     assert_eq!(tree_phyml.robinson_foulds(tree_from_nj), 0);
     assert_eq!(tree.robinson_foulds(tree_from_nj), 0);
 }
+
+#[test]
+fn almost_eq_trees_with_internal_ids() {
+    let tree1 = tree!("((A:1,B:2)E:5,(C:3,D:4)F:6)G:7;");
+    let tree2 = tree!("((D:4.1,C:2.9)F:6.1,(B:2.1,A:0.9)E:4.9)G:7;");
+    let epsilon_ok = 0.10001;
+    assert!(tree1.almost_eq(&tree2, epsilon_ok));
+    let epsilon_not_ok = 0.1;
+    assert!(!tree1.almost_eq(&tree2, epsilon_not_ok));
+}
+
+#[test]
+fn almost_eq_trees_wrong_total_len() {
+    let tree1 = tree!("((A:1,B:2)E:5,(C:3,D:4)F:6)G:7;");
+    let tree2 = tree!("((D:4.1,C:3.1)F:6.1,(B:2.1,A:0.9)E:4.9)G:7;");
+    let epsilon_ok = 0.20001; // > 0.1 is not sufficient even though all blens differ only by 0.1
+                              // because total length differs by 0.2
+    assert!(tree1.almost_eq(&tree2, epsilon_ok));
+    let epsilon_not_ok = 0.1;
+    assert!(!tree1.almost_eq(&tree2, epsilon_not_ok));
+}
+
+#[test]
+fn almost_eq_trees_with_out_internal_ids() {
+    let tree1 = tree!("((A:1,B:2):5,(C:3,D:4):6)G:7;");
+    let tree2 = tree!("((D:4.1,C:2.9):6.1,(B:2.1,A:0.9):4.9)G:7;");
+    let epsilon_ok = 0.10001;
+    assert!(tree1.almost_eq(&tree2, epsilon_ok));
+    let epsilon_not_ok = 0.1;
+    assert!(!tree1.almost_eq(&tree2, epsilon_not_ok));
+}
+
+#[test]
+fn almost_eq_trees_with_wrong_children() {
+    let tree1 = tree!("((A:1,C:3)E:5,(B:2,D:4)F:6)G:7;");
+    let tree2 = tree!("((D:4.1,C:2.9)F:6.1,(B:2.1,A:0.9)E:4.9)G:7;");
+    let epsilon = 100.0;
+    assert!(!tree1.almost_eq(&tree2, epsilon));
+}
+
+#[test]
+#[should_panic]
+fn almost_eq_trees_non_unique_ids_in_first_tree() {
+    // id `A` appears twice
+    let tree1 = tree!("((A:1,B:2)E:5,(A:3,D:4)F:6)G:7;");
+    let tree2 = tree!("((D:4.1,C:2.9)F:6.1,(B:2.1,A:0.9)E:4.9)G:7;");
+    let epsilon = 1.0;
+    assert!(tree1.almost_eq(&tree2, epsilon));
+}
+
+#[test]
+#[should_panic]
+fn almost_eq_trees_non_unique_ids_in_second_tree() {
+    // id `A` appears twice
+    let tree1 = tree!("((A:1,B:2)E:5,(C:3,D:4)F:6)G:7;");
+    let tree2 = tree!("((D:4.1,D:2.9)F:6.1,(B:2.1,A:0.9)E:4.9)G:7;");
+    let epsilon = 1.0;
+    assert!(tree1.almost_eq(&tree2, epsilon));
+}
+
+#[test]
+fn almost_eq_trees_with_missing_internal_ids_in_first_tree() {
+    let tree1 = tree!("((A:1,B:2)E:5,(C:3,D:4):6)G:7;");
+    let tree2 = tree!("((D:4.1,C:2.9)F:6.1,(B:2.1,A:0.9)E:4.9)G:7;");
+    let epsilon = 100.0;
+    assert!(!tree1.almost_eq(&tree2, epsilon));
+}
+
+#[test]
+fn almost_eq_trees_with_missing_internal_ids_in_second_tree() {
+    let tree1 = tree!("((A:1,B:2)E:5,(C:3,D:4):6)G:7;");
+    let tree2 = tree!("((D:4.1,C:2.9):6.1,(B:2.1,A:0.9):4.9)G:7;");
+    let epsilon = 100.0;
+    assert!(!tree1.almost_eq(&tree2, epsilon));
+}
+
+#[test]
+fn almost_eq_trees_with_wrong_leaf_id() {
+    let tree1 = tree!("((A:1,B:2)E:5,(C:3,D:4)F:6)G:7;");
+    let tree2 = tree!("((D:4.1,C:2.9)F:6.1,(B:2.1,T:0.9)E:4.9)G:7;");
+    let epsilon = 100.0;
+    assert!(!tree1.almost_eq(&tree2, epsilon));
+}
+
+#[test]
+fn almost_eq_trees_with_wrong_internal_id() {
+    let tree1 = tree!("((A:1,B:2)E:5,(C:3,D:4):6)G:7;");
+    let tree2 = tree!("((D:4.1,C:2.9):6.1,(B:2.1,A:0.9)T:4.9)G:7;");
+    let epsilon = 100.0;
+    assert!(!tree1.almost_eq(&tree2, epsilon));
+}
+
+// test Tree::is_subtree

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -293,7 +293,7 @@ fn newick_parse_parentheses_around_all() {
 #[test]
 fn newick_parse_whitespace() {
     let trees = from_newick(
-        "     (     (((  (A:1   , B  :   1.0)  \n \n F:1,C:2.0   )G:1,D:3)H:+1.0  ,  E:4)   I:1)\n;\n   ",
+        "     (     (((  (A:1   , B:   1.0)  \n \n F:1,C:2.0   )G:1,D:3)H:+1.0  ,  E:4)   I:1)\n;\n   ",
     );
     assert!(trees.is_ok());
     let tree0 = &trees.unwrap()[0];

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -764,7 +764,7 @@ fn almost_eq_trees_wrong_total_len() {
 }
 
 #[test]
-fn almost_eq_trees_with_out_internal_ids() {
+fn almost_eq_trees_without_internal_ids() {
     let tree1 = tree!("((A:1,B:2):5,(C:3,D:4):6)G:7;");
     let tree2 = tree!("((D:4.1,C:2.9):6.1,(B:2.1,A:0.9):4.9)G:7;");
     let epsilon_ok = 0.10001;

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -300,7 +300,7 @@ fn newick_parse_whitespace() {
     let tree1 = &from_newick("(((((A:1,B:1)F:1,C:2)G:1,D:3)H:1,E:4)I:1);").unwrap()[0];
     assert_eq!(tree0.nodes, tree1.nodes);
     let epsilon = 0.0;
-    assert!(tree0.almost_eq(tree1, epsilon))
+    assert!(tree0.almost_eq(tree1, epsilon));
 }
 
 #[test]

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -832,5 +832,3 @@ fn almost_eq_trees_with_wrong_internal_id() {
     let epsilon = 100.0;
     assert!(!tree1.almost_eq(&tree2, epsilon));
 }
-
-// test Tree::is_subtree


### PR DESCRIPTION
Implemented a `almost_eq` method to compare trees ignoring internal representations. 
Closes #78. As we not want to directly implement `Eq` since we are still comparing `f64` fields for which `Eq` is not implemented.