### PR TITLE
Msa file io and record sort

### DIFF
--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -152,6 +152,8 @@ impl Display for MSA {
             let aligned_seq = aligned_seq!(seq_map, record.seq());
             aligned_records.push(record!(id, record.desc(), &aligned_seq));
         }
+        // sort records by id to have a consistent output
+        aligned_records.sort_by(|a, b| a.id().cmp(b.id()));
         write!(f, "{}", Sequences::new(aligned_records))
     }
 }
@@ -351,6 +353,8 @@ pub struct MASA {
 impl Display for MASA {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let both_maps = self.leaf_maps.iter().chain(self.ancestral_maps.iter());
+        let mut aligned_records =
+            Vec::with_capacity(self.leaf_seqs.len() + self.ancestral_seqs.len());
         for (node_idx, seq_map) in both_maps {
             let id = &self.idx_to_id[usize::from(node_idx)];
             let record = match node_idx {
@@ -358,9 +362,11 @@ impl Display for MASA {
                 Leaf(_) => self.leaf_seqs.record_by_id(id),
             };
             let aligned_seq = aligned_seq!(seq_map, record.seq());
-            write!(f, "{}", record!(id, record.desc(), &aligned_seq))?;
+            aligned_records.push(record!(id, record.desc(), &aligned_seq));
         }
-        Ok(())
+        // sort records by id to have a consistent output
+        aligned_records.sort_by(|a, b| a.id().cmp(b.id()));
+        write!(f, "{}", Sequences::new(aligned_records))
     }
 }
 

--- a/phylo/src/alignment/mod.rs
+++ b/phylo/src/alignment/mod.rs
@@ -152,8 +152,12 @@ impl Display for MSA {
             let aligned_seq = aligned_seq!(seq_map, record.seq());
             aligned_records.push(record!(id, record.desc(), &aligned_seq));
         }
-        // sort records by id to have a consistent output
-        aligned_records.sort_by(|a, b| a.id().cmp(b.id()));
+        // sort records to have a consistent output
+        aligned_records.sort_by(|a, b| {
+            a.id()
+                .cmp(b.id())
+                .then(a.desc().cmp(&b.desc()).then(a.seq().cmp(b.seq())))
+        });
         write!(f, "{}", Sequences::new(aligned_records))
     }
 }
@@ -364,8 +368,12 @@ impl Display for MASA {
             let aligned_seq = aligned_seq!(seq_map, record.seq());
             aligned_records.push(record!(id, record.desc(), &aligned_seq));
         }
-        // sort records by id to have a consistent output
-        aligned_records.sort_by(|a, b| a.id().cmp(b.id()));
+        // sort records to have a consistent output
+        aligned_records.sort_by(|a, b| {
+            a.id()
+                .cmp(b.id())
+                .then(a.desc().cmp(&b.desc()).then(a.seq().cmp(b.seq())))
+        });
         write!(f, "{}", Sequences::new(aligned_records))
     }
 }

--- a/phylo/src/alignment/tests.rs
+++ b/phylo/src/alignment/tests.rs
@@ -8,6 +8,7 @@ use crate::alignment::{
 use crate::alphabets::{Alphabet, AMINOACIDS, NUCLEOTIDES};
 use crate::io::read_sequences;
 use crate::phylo_info::PhyloInfo;
+use crate::random::{FakeGenerator, FakeRng};
 use crate::tree::{
     NodeIdx::{Internal as I, Leaf as L},
     Tree,
@@ -306,18 +307,18 @@ fn display_unaligned_sequences() {
 fn fmt_alignment() {
     // arrange
     let tree = tree!("(C:0.06465432,D:27.43128366,(A:0.00000001,B:0.00000001):0.08716381);");
-    let sequences = Sequences::new(read_sequences("./data/sequences_DNA1.fasta").unwrap());
-    let msa = MSA::from_aligned(sequences, &tree).unwrap();
+    let mut rng = FakeGenerator::from_rng(FakeRng::from_u64_values(vec![29, 1, 8, 47]));
+    let mut records = read_sequences("./data/sequences_DNA1.fasta").unwrap();
+    rng.shuffle(&mut records);
+    let msa = MSA::from_aligned(Sequences::new(records), &tree).unwrap();
     let true_content = std::fs::read_to_string("./data/sequences_DNA1.fasta").unwrap();
-    let mut true_lines = true_content.lines().collect::<Vec<_>>();
-    true_lines.sort();
+    let true_lines = true_content.lines().collect::<Vec<_>>();
 
     // act
     let s = format!("{msa}");
 
     // assert
-    let mut lines = s.lines().collect::<Vec<_>>();
-    lines.sort();
+    let lines = s.lines().collect::<Vec<_>>();
     assert_eq!(lines.len(), 8);
     assert_eq!(lines, true_lines);
 }
@@ -325,17 +326,17 @@ fn fmt_alignment() {
 #[test]
 fn display_alignment() {
     let tree = tree!("(C:0.06465432,D:27.43128366,(A:0.00000001,B:0.00000001):0.08716381);");
-    let sequences = Sequences::new(read_sequences("./data/sequences_DNA1.fasta").unwrap());
-    let msa = MSA::from_aligned(sequences, &tree).unwrap();
+    let mut rng = FakeGenerator::from_rng(FakeRng::from_u64_values(vec![29, 1, 8, 47]));
+    let mut records = read_sequences("./data/sequences_DNA1.fasta").unwrap();
+    rng.shuffle(&mut records);
+    let msa = MSA::from_aligned(Sequences::new(records), &tree).unwrap();
 
     let s = format!("{msa}");
-    let mut lines = s.lines().collect::<Vec<_>>();
-    lines.sort();
+    let lines = s.lines().collect::<Vec<_>>();
     assert_eq!(lines.len(), 8);
 
     let s = std::fs::read_to_string("./data/sequences_DNA1.fasta").unwrap();
-    let mut true_lines = s.lines().collect::<Vec<_>>();
-    true_lines.sort();
+    let true_lines = s.lines().collect::<Vec<_>>();
 
     assert_eq!(lines, true_lines);
 }
@@ -344,19 +345,19 @@ fn display_alignment() {
 fn display_ancestral_alignment() {
     // arrange
     let tree = tree!("((C:0.1,D:0.2)I01:0.3,(A:0.4,B:0.5)I02:0.6)Root;");
-    let sequences =
-        Sequences::new(read_sequences("./data/sequences_DNA1_with_ancestors.fasta").unwrap());
-    let msa = MASA::from_aligned_with_ancestral(sequences, &tree).unwrap();
+    let mut rng =
+        FakeGenerator::from_rng(FakeRng::from_u64_values(vec![29, 1, 8, 47, 99, 23, 56, 78]));
+    let mut records = read_sequences("./data/sequences_DNA1_with_ancestors.fasta").unwrap();
+    rng.shuffle(&mut records);
+    let msa = MASA::from_aligned_with_ancestral(Sequences::new(records), &tree).unwrap();
     let true_lines = std::fs::read_to_string("./data/sequences_DNA1_with_ancestors.fasta").unwrap();
-    let mut true_lines = true_lines.lines().collect::<Vec<_>>();
-    true_lines.sort();
+    let true_lines = true_lines.lines().collect::<Vec<_>>();
 
     // act
     let lines = format!("{msa}");
 
     // assert
-    let mut lines = lines.lines().collect::<Vec<_>>();
-    lines.sort();
+    let lines = lines.lines().collect::<Vec<_>>();
     assert_eq!(lines.len(), 14);
     assert_eq!(lines, true_lines);
 }

--- a/phylo/src/io/mod.rs
+++ b/phylo/src/io/mod.rs
@@ -8,6 +8,7 @@ use anyhow::bail;
 use bio::io::fasta::{Reader, Record, Writer};
 use log::info;
 
+use crate::alignment::{Alignment, AncestralAlignment};
 use crate::alphabets::{Alphabet, GAP, POSSIBLE_GAPS};
 use crate::tree::{tree_parser, Tree};
 use crate::{record, Result};
@@ -128,6 +129,39 @@ pub fn write_sequences_to_file(sequences: &[Record], path: impl AsRef<Path>) -> 
     for rec in sequences {
         writer.write_record(rec)?;
     }
+    info!("Finished writing successfully");
+    Ok(())
+}
+
+/// Writes the MSA to the given file path as a fasta file with the sequences sorted by ID.
+/// Will return an error if the file already exists.
+pub fn write_msa_to_file<A: Alignment>(msa: &A, path: impl AsRef<Path>) -> Result<()> {
+    info!("Writing MSA to file {}", path.as_ref().display());
+    if path.as_ref().exists() {
+        bail!(DataError {
+            message: String::from("File already exists")
+        });
+    }
+    let mut file = File::create(path)?;
+    write!(file, "{}", msa)?;
+
+    info!("Finished writing successfully");
+    Ok(())
+}
+
+/// Writes the MASA to the given file path as a fasta file with the sequences sorted by ID.
+/// That is, both leaf and ancestral sequences are written.
+/// Will return an error if the file already exists.
+pub fn write_masa_to_file<AA: AncestralAlignment>(msa: &AA, path: impl AsRef<Path>) -> Result<()> {
+    info!("Writing MASA to file {}", path.as_ref().display());
+    if path.as_ref().exists() {
+        bail!(DataError {
+            message: String::from("File already exists")
+        });
+    }
+    let mut file = File::create(path)?;
+    write!(file, "{}", msa)?;
+
     info!("Finished writing successfully");
     Ok(())
 }

--- a/phylo/src/io/mod.rs
+++ b/phylo/src/io/mod.rs
@@ -133,27 +133,11 @@ pub fn write_sequences_to_file(sequences: &[Record], path: impl AsRef<Path>) -> 
     Ok(())
 }
 
-/// Writes the MSA to the given file path as a fasta file with the sequences sorted by ID.
+/// Writes the Alignment to the given file path as a fasta file with the sequences sorted by ID.
+/// Uses the `Display` implementation of the Alignment.
 /// Will return an error if the file already exists.
 pub fn write_msa_to_file<A: Alignment>(msa: &A, path: impl AsRef<Path>) -> Result<()> {
     info!("Writing MSA to file {}", path.as_ref().display());
-    if path.as_ref().exists() {
-        bail!(DataError {
-            message: String::from("File already exists")
-        });
-    }
-    let mut file = File::create(path)?;
-    write!(file, "{}", msa)?;
-
-    info!("Finished writing successfully");
-    Ok(())
-}
-
-/// Writes the MASA to the given file path as a fasta file with the sequences sorted by ID.
-/// That is, both leaf and ancestral sequences are written.
-/// Will return an error if the file already exists.
-pub fn write_masa_to_file<AA: AncestralAlignment>(msa: &AA, path: impl AsRef<Path>) -> Result<()> {
-    info!("Writing MASA to file {}", path.as_ref().display());
     if path.as_ref().exists() {
         bail!(DataError {
             message: String::from("File already exists")

--- a/phylo/src/io/tests.rs
+++ b/phylo/src/io/tests.rs
@@ -4,7 +4,9 @@ use std::io::Read;
 use rstest::*;
 use tempfile::tempdir;
 
-use crate::io::{read_sequences, write_newick_to_file, write_sequences_to_file};
+use crate::alignment::{Alignment, AncestralAlignment, Sequences, MASA, MSA};
+use crate::io::{read_sequences, write_msa_to_file, write_newick_to_file, write_sequences_to_file};
+use crate::random::{FakeGenerator, FakeRng};
 use crate::{record_wo_desc as record, tree};
 
 #[test]
@@ -155,4 +157,53 @@ fn read_sequences_weird_gap_chars() {
         assert_eq!(seq.seq(), sequences_underscore[i].seq());
         assert_eq!(seq.seq(), sequences_asterisk[i].seq());
     }
+}
+
+#[test]
+fn write_msa() {
+    // arrange
+    let tree = tree!("(C:0.06465432,D:27.43128366,(A:0.00000001,B:0.00000001):0.08716381);");
+    let mut rng = FakeGenerator::from_rng(FakeRng::from_u64_values(vec![29, 1, 8, 47]));
+    let mut records = read_sequences("./data/sequences_DNA1.fasta").unwrap();
+    rng.shuffle(&mut records);
+    let msa = MSA::from_aligned(Sequences::new(records), &tree).unwrap();
+    let temp_dir = tempdir().unwrap();
+    let output_path = temp_dir.path().join("output.fasta");
+    let true_content = std::fs::read_to_string("./data/sequences_DNA1.fasta").unwrap();
+
+    // act
+    write_msa_to_file(&msa, output_path.clone()).unwrap();
+
+    // assert
+    let mut file_content = String::new();
+    std::fs::File::open(output_path)
+        .unwrap()
+        .read_to_string(&mut file_content)
+        .unwrap();
+    assert_eq!(file_content.trim(), true_content);
+}
+
+#[test]
+fn write_masa() {
+    // arrange
+    let tree = tree!("((C:0.1,D:0.2)I01:0.3,(A:0.4,B:0.5)I02:0.6)Root;");
+    let mut rng = FakeGenerator::from_rng(FakeRng::from_u64_values(vec![29, 1, 8, 47]));
+    let mut records = read_sequences("./data/sequences_DNA1_with_ancestors.fasta").unwrap();
+    rng.shuffle(&mut records);
+    let msa = MASA::from_aligned_with_ancestral(Sequences::new(records), &tree).unwrap();
+    let temp_dir = tempdir().unwrap();
+    let output_path = temp_dir.path().join("output.fasta");
+    let true_content =
+        std::fs::read_to_string("./data/sequences_DNA1_with_ancestors.fasta").unwrap();
+
+    // act
+    write_msa_to_file(&msa, output_path.clone()).unwrap();
+
+    // assert
+    let mut file_content = String::new();
+    std::fs::File::open(output_path)
+        .unwrap()
+        .read_to_string(&mut file_content)
+        .unwrap();
+    assert_eq!(file_content, true_content);
 }


### PR DESCRIPTION
Sorting records in MSA and MASA by id, then desc, then seq when outputting with fmt or to a file. 
Implemented write_msa_to_file.