### PR TITLE
Add debug print for test results in workflow

### DIFF
--- a/.github/workflows/test_PRs.yml
+++ b/.github/workflows/test_PRs.yml
@@ -55,6 +55,9 @@ jobs:
     - name: tests with cargo2junit
       run: |
         cargo test --manifest-path ./phylo/Cargo.toml -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
+    - name: Debug print of results to see failed test. Since PRs from forked repos cannot be published.
+      run: |
+        cat results.xml
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()

--- a/.github/workflows/test_PRs.yml
+++ b/.github/workflows/test_PRs.yml
@@ -55,7 +55,7 @@ jobs:
     - name: tests with cargo2junit
       run: |
         cargo test --manifest-path ./phylo/Cargo.toml -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
-    - name: Debug print of results to see failed test. Since PRs from forked repos cannot be published.
+    - name: Debug print of results to see failed test names
       run: |
         cat results.xml
     - name: Publish test results

--- a/.github/workflows/test_PRs.yml
+++ b/.github/workflows/test_PRs.yml
@@ -51,11 +51,20 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - name: install cargo2junit
       run: |
-          cargo install cargo2junit
-    - name: tests with cargo2junit
+        cargo install cargo2junit
+    - name: Running cargo tests 
       run: |
-        cargo test --manifest-path ./phylo/Cargo.toml -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
-    - name: Debug print of results to see failed test names
+        cargo test --manifest-path ./phylo/Cargo.toml -- -Z unstable-options --format json --report-time > cargo_test.out
+    - name: Display cargo test output
+      if: always()
+      run: |
+        cat cargo_test.out
+    - name: Running cargo2junit
+      if: always()
+      run: |
+        cargo2junit < cargo_test.out > results.xml
+    - name: Display cargo2junit output
+      if: always()
       run: |
         cat results.xml
     - name: Publish test results

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -49,9 +49,21 @@ jobs:
     - name: install cargo2junit
       run: |
           cargo install cargo2junit
-    - name: tests with cargo2junit
+    - name: Running cargo tests 
       run: |
-        cargo test --manifest-path ./phylo/Cargo.toml -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
+        cargo test --manifest-path ./phylo/Cargo.toml -- -Z unstable-options --format json --report-time > cargo_test.out
+    - name: Display cargo test output
+      if: always()
+      run: |
+        cat cargo_test.out
+    - name: Running cargo2junit
+      if: always()
+      run: |
+        cargo2junit < cargo_test.out > results.xml
+    - name: Display cargo2junit output
+      if: always()
+      run: |
+        cat results.xml
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
@@ -70,9 +82,21 @@ jobs:
     - name: install cargo2junit
       run: |
           cargo install cargo2junit
-    - name: tests with cargo2junit
+    - name: Running cargo tests 
       run: |
-        cargo test --manifest-path ./phylo/Cargo.toml --features par-regraft-chunk -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
+        cargo test --manifest-path ./phylo/Cargo.toml --features par-regraft-chunk -- -Z unstable-options --format json --report-time > cargo_test.out
+    - name: Display cargo test output
+      if: always()
+      run: |
+        cat cargo_test.out
+    - name: Running cargo2junit
+      if: always()
+      run: |
+        cargo2junit < cargo_test.out > results.xml
+    - name: Display cargo2junit output
+      if: always()
+      run: |
+        cat results.xml
 
   test_par_regraft_manual:
     name: cargo test par-regraft-manual
@@ -85,6 +109,18 @@ jobs:
     - name: install cargo2junit
       run: |
           cargo install cargo2junit
-    - name: tests with cargo2junit
+    - name: Running cargo tests 
       run: |
-        cargo test --manifest-path ./phylo/Cargo.toml --features par-regraft-manual -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
+        cargo test --manifest-path ./phylo/Cargo.toml --features par-regraft-manual -- -Z unstable-options --format json --report-time > cargo_test.out
+    - name: Display cargo test output
+      if: always()
+      run: |
+        cat cargo_test.out
+    - name: Running cargo2junit
+      if: always()
+      run: |
+        cargo2junit < cargo_test.out > results.xml
+    - name: Display cargo2junit output
+      if: always()
+      run: |
+        cat results.xml

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -856,3 +856,8 @@ fn tkf_modify_indel_model_params_costs_match() {
     modify_tkf92_indel_params_costs_match_template::<BLOSUM>();
     modify_tkf92_indel_params_costs_match_template::<HIVB>();
 }
+
+#[test]
+fn failing_test_to_see_github_action_output() {
+    assert_eq!(1, 2);
+}

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -859,5 +859,5 @@ fn tkf_modify_indel_model_params_costs_match() {
 
 #[test]
 fn failing_test_to_see_github_action_output() {
-    assert_eq!(1, 2);
+    assert_eq!(1, 3);
 }

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -856,8 +856,3 @@ fn tkf_modify_indel_model_params_costs_match() {
     modify_tkf92_indel_params_costs_match_template::<BLOSUM>();
     modify_tkf92_indel_params_costs_match_template::<HIVB>();
 }
-
-#[test]
-fn failing_test_to_see_github_action_output() {
-    assert_eq!(1, 3);
-}


### PR DESCRIPTION
Pulled the cmd 
`cargo test --manifest-path ./phylo/Cargo.toml -- -Z unstable-options --format json --report-time | cargo2junit > results.xml`
apart: 
```
cargo test --manifest-path ./phylo/Cargo.toml -- -Z unstable-options --format json --report-time > cargo_test.out
cat cargo_test.out
cargo2junit < cargo_test.out > results.xml
cat results.xml
```
Therefore, even if publishing the results fails we can look at std::out and see which tests failed.