### PR TITLE
refactor: update TKF cost builders to use parameter slices

### DIFF
--- a/phylo/src/optimisers/model_optimiser_tests.rs
+++ b/phylo/src/optimisers/model_optimiser_tests.rs
@@ -616,7 +616,7 @@ fn tkf91_model_opti() {
         .build_with_ancestors()
         .unwrap();
     let subst_model = SubstModel::<HKY>::new(&[], &[2.0]);
-    let tkf91 = TKF91CostBuilder::new(0.8, 1.0, subst_model.clone(), info.clone())
+    let tkf91 = TKF91CostBuilder::new(&[0.8, 1.0], subst_model.clone(), info.clone())
         .build()
         .unwrap();
     tkf_model_opti_template(tkf91);
@@ -630,7 +630,7 @@ fn tkf92_model_opti() {
         .build_with_ancestors()
         .unwrap();
     let subst_model = SubstModel::<HKY>::new(&[], &[2.0]);
-    let tkf92 = TKF92CostBuilder::new(0.8, 1.0, 0.2, subst_model, info)
+    let tkf92 = TKF92CostBuilder::new(&[0.8, 1.0, 0.2], subst_model, info)
         .build()
         .unwrap();
     tkf_model_opti_template(tkf92);

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -974,9 +974,7 @@ fn tkf92_topo_opti() {
             tree: result.cost.tree().clone(),
         };
         let new_indel_cost = TKF92IndelAddBlocksCostBuilder::new(
-            lambda,
-            mu,
-            r,
+            &[lambda, mu, r],
             initial_msa_blocking.clone(),
             new_phylo.clone(),
         )

--- a/phylo/src/optimisers/topo_optimiser_tests.rs
+++ b/phylo/src/optimisers/topo_optimiser_tests.rs
@@ -951,7 +951,7 @@ fn tkf92_topo_opti() {
     let lambda = 0.1;
     let mu = 0.2;
     let r = 0.3;
-    let tkf_cost = TKF92CostBuilder::new(lambda, mu, r, subst_model.clone(), phylo.clone())
+    let tkf_cost = TKF92CostBuilder::new(&[lambda, mu, r], subst_model.clone(), phylo.clone())
         .build()
         .unwrap();
     let unopt_cost = tkf_cost.cost();

--- a/phylo/src/tkf_model/mod.rs
+++ b/phylo/src/tkf_model/mod.rs
@@ -127,7 +127,7 @@ impl<Q: QMatrix, T: TKFModel, AA: AncestralAlignment> TKFCost<Q, T, AA> {
     /// )?;
     /// let phylo = PhyloInfo { msa, tree };
     /// let subst_model = SubstModel::<GTR>::new(&[], &[]);
-    /// let cost = TKF92CostBuilder::new(0.4, 0.5, 0.8, subst_model, phylo).build()?;
+    /// let cost = TKF92CostBuilder::new(&[0.4, 0.5, 0.8], subst_model, phylo).build()?;
     /// assert_eq!(cost.masa().seqs().len(), 3);
     /// assert_eq!(cost.masa().ancestral_seqs().len(), 2);
     /// # Ok(()) }
@@ -161,7 +161,7 @@ impl<Q: QMatrix, T: TKFModel, AA: AncestralAlignment> TKFCost<Q, T, AA> {
     /// )?;
     /// let phylo = PhyloInfo { msa, tree };
     /// let subst_model = SubstModel::<GTR>::new(&[], &[]);
-    /// let cost = TKF92CostBuilder::new(0.4, 0.5, 0.8, subst_model, phylo).build()?;
+    /// let cost = TKF92CostBuilder::new(&[0.4, 0.5, 0.8], subst_model, phylo).build()?;
     /// // under the TKF92 model the blocks are the positions in the alignment where there is
     /// // a sequence that changes from gap to non-gap or vice versa (always including the last
     /// // position of the alignment).

--- a/phylo/src/tkf_model/reestimate/brute_force_ancestors_tests.rs
+++ b/phylo/src/tkf_model/reestimate/brute_force_ancestors_tests.rs
@@ -427,7 +427,7 @@ fn tkf92_reestimate_large_tree_for_file_iterative() {
     load_precalculated_brute_force_maxes(&precalculated_file, &mut iteration_info);
 
     // the cost to be used for repeated reestimation
-    let mut reestimator_cost = TKF92IndelCostBuilder::new(lambda, mu, r, phylo.clone())
+    let mut reestimator_cost = TKF92IndelCostBuilder::new(&[lambda, mu, r], phylo.clone())
         .build()
         .unwrap();
     // cloning here to leave the cost in a clean state before reestimation

--- a/phylo/src/tkf_model/reestimate/brute_force_ancestors_tests.rs
+++ b/phylo/src/tkf_model/reestimate/brute_force_ancestors_tests.rs
@@ -455,9 +455,7 @@ fn tkf92_reestimate_large_tree_for_file_iterative() {
         let max_dp = reestimator.reestimate_unchecked(node);
         // Perform brute force calculation
         let cost_for_brute_force = TKF92IndelAddBlocksCostBuilder::new(
-            lambda,
-            mu,
-            r,
+            &[lambda, mu, r],
             initial_msa_blocking.clone(),
             reestimator.phylo().clone(),
         )
@@ -473,9 +471,7 @@ fn tkf92_reestimate_large_tree_for_file_iterative() {
         );
         // Create a clean cost to compare against
         let clean_cost = TKF92IndelAddBlocksCostBuilder::new(
-            lambda,
-            mu,
-            r,
+            &[lambda, mu, r],
             initial_msa_blocking.clone(),
             reestimator.phylo().clone(),
         )

--- a/phylo/src/tkf_model/reestimate/cache.rs
+++ b/phylo/src/tkf_model/reestimate/cache.rs
@@ -437,7 +437,7 @@ mod private_tests {
     #[test]
     fn tkf_possible_del_or_not_table_idx_without_root() {
         let phylo = setup_test_phylo(Alphabet::dna());
-        let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+        let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
             .build()
             .unwrap();
         let rng = &mut FakeGenerator::default();
@@ -475,7 +475,7 @@ mod private_tests {
     fn tkf_possible_del_or_not_table_idx_with_root() {
         let phylo = setup_test_phylo(Alphabet::dna());
         let root = phylo.tree.root;
-        let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+        let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
             .build()
             .unwrap();
         let rng = &mut FakeGenerator::default();

--- a/phylo/src/tkf_model/reestimate/mod.rs
+++ b/phylo/src/tkf_model/reestimate/mod.rs
@@ -165,7 +165,7 @@ struct BackTrackingResult {
 /// let lambda = 0.9;
 /// let mu = 1.0;
 /// let r = 0.5;
-/// let mut tkf92_indel_cost = TKF92IndelCostBuilder::new(lambda, mu, r, phylo)
+/// let mut tkf92_indel_cost = TKF92IndelCostBuilder::new(&[lambda, mu, r], phylo)
 ///     .build()?;
 /// let mut rng = DefaultGenerator::default();
 /// let mut reestimator = EdgeSeqsReestimator::new(&mut tkf92_indel_cost, &mut rng);
@@ -819,7 +819,7 @@ mod private_tests {
         #[case] expected_events: QuartetEvents,
     ) {
         let phylo = setup_test_phylo(Alphabet::dna());
-        let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+        let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
             .build()
             .unwrap();
         let rng = &mut FakeGenerator::default();
@@ -835,7 +835,7 @@ mod private_tests {
     fn tkf_backtrack() {
         let phylo = setup_test_phylo(Alphabet::dna());
         // the parameters here do not matter for the backtracking test
-        let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+        let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
             .build()
             .unwrap();
         // FakeRng such that we can test tie-breaking (max value in last column) in backtracking
@@ -912,7 +912,7 @@ mod private_tests {
         )
         .unwrap();
         let phylo = PhyloInfo { msa, tree };
-        let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+        let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
             .build()
             .unwrap();
         let logl = cost.logl(); // must be called to initialize the model_info, which is
@@ -925,7 +925,7 @@ mod private_tests {
     #[test]
     fn tkf_remove_and_add_back_quartet() {
         let phylo = setup_test_phylo(Alphabet::dna());
-        let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+        let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
             .build()
             .unwrap();
 
@@ -950,7 +950,7 @@ mod private_tests {
             .build_with_ancestors()
             .unwrap();
 
-        let mut cost = TKF92IndelCostBuilder::new(1.0, 2.0, 0.3, phylo)
+        let mut cost = TKF92IndelCostBuilder::new(&[1.0, 2.0, 0.3], phylo)
             .build()
             .unwrap();
         let rng = &mut DefaultGenerator::default();
@@ -982,7 +982,7 @@ mod private_tests {
             .build_with_ancestors()
             .unwrap();
 
-        let mut cost = TKF92IndelCostBuilder::new(1.0, 2.0, 0.3, phylo)
+        let mut cost = TKF92IndelCostBuilder::new(&[1.0, 2.0, 0.3], phylo)
             .build()
             .unwrap();
         let rng = &mut DefaultGenerator::default();

--- a/phylo/src/tkf_model/reestimate/tests.rs
+++ b/phylo/src/tkf_model/reestimate/tests.rs
@@ -30,7 +30,7 @@ fn tkf_reestimate_without_choice() {
     )
     .unwrap();
     let phylo = PhyloInfo { msa, tree };
-    let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+    let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
         .build()
         .unwrap();
     let logl = cost.clone().logl();
@@ -52,7 +52,7 @@ fn tkf_reestimate_without_choice() {
 #[test]
 fn tkf_reestimation_fails_for_root() {
     let phylo = setup_test_phylo(Alphabet::dna());
-    let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+    let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
         .build()
         .unwrap();
     let rng = &mut FakeGenerator::default();
@@ -66,7 +66,7 @@ fn tkf_reestimation_fails_for_root() {
 #[test]
 fn tkf_reestimation_fails_for_leaf() {
     let phylo = setup_test_phylo(Alphabet::dna());
-    let mut cost = TKF92IndelCostBuilder::new(0.4, 0.5, 0.8, phylo)
+    let mut cost = TKF92IndelCostBuilder::new(&[0.4, 0.5, 0.8], phylo)
         .build()
         .unwrap();
     let rng = &mut FakeGenerator::default();

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -320,7 +320,7 @@ pub(super) fn setup_test_phylo(alphabet: &'static Alphabet) -> PhyloInfo<MASA> {
 #[test]
 fn tkf_indel_get_and_set_params_and_freqs() {
     let mut tkf_indel_cost =
-        TKF92IndelCostBuilder::new(1.0, 2.0, 0.3, setup_test_phylo(Alphabet::dna()))
+        TKF92IndelCostBuilder::new(&[1.0, 2.0, 0.3], setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
     // params
@@ -348,9 +348,7 @@ fn tkf_indel_get_and_set_params_and_freqs() {
 fn tkf_get_and_set_params() {
     let subst_model = SubstModel::<GTR>::new(&[0.1, 0.2, 0.3, 0.4], &[0.5, 0.6, 0.7, 0.8, 0.9]);
     let mut tkf_cost = TKF92CostBuilder::new(
-        1.0,
-        2.0,
-        0.3,
+        &[1.0, 2.0, 0.3],
         subst_model,
         setup_test_phylo(Alphabet::dna()),
     )
@@ -388,7 +386,7 @@ fn tkf_get_and_set_params() {
 
 #[test]
 fn tkf91_indel_cost_fmt() {
-    let tkf_indel_cost = TKF91IndelCostBuilder::new(1.0, 2.0, setup_test_phylo(Alphabet::dna()))
+    let tkf_indel_cost = TKF91IndelCostBuilder::new(&[1.0, 2.0], setup_test_phylo(Alphabet::dna()))
         .build()
         .unwrap();
 
@@ -400,9 +398,10 @@ fn tkf91_indel_cost_fmt() {
 #[test]
 fn tkf91_cost_fmt() {
     let subst_model = SubstModel::<JC69>::new(&[], &[]);
-    let tkf_cost = TKF91CostBuilder::new(1.0, 2.0, subst_model, setup_test_phylo(Alphabet::dna()))
-        .build()
-        .unwrap();
+    let tkf_cost =
+        TKF91CostBuilder::new(&[1.0, 2.0], subst_model, setup_test_phylo(Alphabet::dna()))
+            .build()
+            .unwrap();
 
     let fmt = format!("{}", tkf_cost);
 
@@ -412,7 +411,7 @@ fn tkf91_cost_fmt() {
 #[test]
 fn tkf92_indel_cost_fmt() {
     let tkf_indel_cost =
-        TKF92IndelCostBuilder::new(1.0, 2.0, 0.3, setup_test_phylo(Alphabet::dna()))
+        TKF92IndelCostBuilder::new(&[1.0, 2.0, 0.3], setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
 
@@ -425,9 +424,7 @@ fn tkf92_indel_cost_fmt() {
 fn tkf92_cost_fmt() {
     let subst_model = SubstModel::<JC69>::new(&[], &[]);
     let tkf_cost = TKF92CostBuilder::new(
-        1.0,
-        2.0,
-        0.3,
+        &[1.0, 2.0, 0.3],
         subst_model,
         setup_test_phylo(Alphabet::dna()),
     )
@@ -443,9 +440,7 @@ fn tkf92_cost_fmt() {
 fn tkf_get_and_set_freqs() {
     let subst_model = SubstModel::<GTR>::new(&[0.1, 0.2, 0.3, 0.4], &[0.5, 0.6, 0.7, 0.8, 0.9]);
     let mut tkf_cost = TKF92CostBuilder::new(
-        1.0,
-        2.0,
-        0.3,
+        &[1.0, 2.0, 0.3],
         subst_model,
         setup_test_phylo(Alphabet::dna()),
     )
@@ -459,13 +454,14 @@ fn tkf_get_and_set_freqs() {
 #[test]
 fn tkf91_param_range() {
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
-    let tkf_cost = TKF91CostBuilder::new(1.0, 2.0, subst_model, setup_test_phylo(Alphabet::dna()))
-        .build()
-        .unwrap();
-    let lambda_range = tkf_cost.param_range(usize::from(TKF92Parameters::Lambda));
+    let tkf_cost =
+        TKF91CostBuilder::new(&[1.0, 2.0], subst_model, setup_test_phylo(Alphabet::dna()))
+            .build()
+            .unwrap();
+    let lambda_range = tkf_cost.param_range(usize::from(TKF91Parameters::Lambda));
     let true_lambda_range = (f64::EPSILON, 2.0 - f64::EPSILON);
     assert_eq!(lambda_range, true_lambda_range);
-    let mu_range = tkf_cost.param_range(usize::from(TKF92Parameters::Mu));
+    let mu_range = tkf_cost.param_range(usize::from(TKF91Parameters::Mu));
     let true_mu_range = (1.0 + f64::EPSILON, f64::MAX);
     assert_eq!(mu_range, true_mu_range);
 
@@ -503,9 +499,7 @@ fn tkf92_indel_param_range<T: TKFModel, AA: AncestralAlignment>(cost: &TKFIndelC
 fn tkf92_param_range() {
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
     let tkf_cost = TKF92CostBuilder::new(
-        1.0,
-        2.0,
-        0.3,
+        &[1.0, 2.0, 0.3],
         subst_model,
         setup_test_phylo(Alphabet::dna()),
     )
@@ -556,7 +550,7 @@ fn tkf91_indel_logl() {
     };
     let lambda = 0.1;
     let mu = 0.2;
-    let tkf91_cost = TKF91IndelCostBuilder::new(lambda, mu, phylo)
+    let tkf91_cost = TKF91IndelCostBuilder::new(&[lambda, mu], phylo)
         .build()
         .unwrap();
 
@@ -635,7 +629,7 @@ fn tkf92_indel_logl() {
     let lambda = 0.1;
     let mu = 0.2;
     let r = 0.3;
-    let tkf92_cost = TKF92IndelCostBuilder::new(lambda, mu, r, phylo)
+    let tkf92_cost = TKF92IndelCostBuilder::new(&[lambda, mu, r], phylo)
         .build()
         .unwrap();
 
@@ -700,7 +694,7 @@ fn tkf91_cost_builder_fails() {
     let phylo = setup_test_phylo(Alphabet::protein());
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
 
-    let tkf91_err = TKF91CostBuilder::new(0.1, 0.2, subst_model, phylo).build();
+    let tkf91_err = TKF91CostBuilder::new(&[0.1, 0.2], subst_model, phylo).build();
 
     assert_matches!(
         tkf91_err, Err(Error::Alphabet(msg)) if msg.contains(
@@ -713,7 +707,7 @@ fn tkf92_cost_builder_fails() {
     let phylo = setup_test_phylo(Alphabet::protein());
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
 
-    let tkf92_err = TKF92CostBuilder::new(0.1, 0.2, 0.3, subst_model, phylo).build();
+    let tkf92_err = TKF92CostBuilder::new(&[0.1, 0.2, 0.3], subst_model, phylo).build();
 
     assert_matches!(
         tkf92_err, Err(Error::Alphabet(msg)) if msg.contains(
@@ -731,7 +725,7 @@ fn tkf91_logl_with_substitution() {
         .unwrap();
     let lambda = 0.1;
     let mu = 0.2;
-    let tkf_cost = TKF91CostBuilder::new(lambda, mu, subst_model, phylo)
+    let tkf_cost = TKF91CostBuilder::new(&[lambda, mu], subst_model, phylo)
         .build()
         .unwrap();
 
@@ -758,7 +752,7 @@ fn tkf92_logl_with_substitution() {
     let lambda = 0.1;
     let mu = 0.2;
     let r = 0.3;
-    let tkf_cost = TKF92CostBuilder::new(lambda, mu, r, subst_model, phylo)
+    let tkf_cost = TKF92CostBuilder::new(&[lambda, mu, r], subst_model, phylo)
         .build()
         .unwrap();
 
@@ -803,11 +797,11 @@ fn tkf_indel_history_doesnt_change_felsenstein() {
     let mu = 0.2;
     let r = 0.3;
     let subst_model = SubstModel::<GTR>::new(&[0.1, 0.3, 0.4, 0.2], &[1.2, 0.5, 5.0, 1.0, 1.0]);
-    let tkf_cost1 = TKF92CostBuilder::new(lambda, mu, r, subst_model.clone(), phylo1)
+    let tkf_cost1 = TKF92CostBuilder::new(&[lambda, mu, r], subst_model.clone(), phylo1)
         .build()
         .unwrap();
 
-    let tkf_cost2 = TKF92CostBuilder::new(lambda, mu, r, subst_model, phylo2)
+    let tkf_cost2 = TKF92CostBuilder::new(&[lambda, mu, r], subst_model, phylo2)
         .build()
         .unwrap();
 
@@ -837,7 +831,7 @@ fn modify_tkf92_subst_params_costs_match_template<Q: QMatrix + QMatrixMaker>() {
     let subst_original_param = 1.0;
     let subst_changed_param = 0.5;
     let subst_model = SubstModel::<Q>::new(&[], &[subst_original_param]);
-    let mut tkf_cost = TKF92CostBuilder::new(0.1, 0.2, 0.3, subst_model, phylo.clone())
+    let mut tkf_cost = TKF92CostBuilder::new(&[0.1, 0.2, 0.3], subst_model, phylo.clone())
         .build()
         .unwrap();
 
@@ -853,7 +847,7 @@ fn modify_tkf92_subst_params_costs_match_template<Q: QMatrix + QMatrixMaker>() {
 
     // The likelihood should be the same if we rebuild from scratch with the same modification
     let subst_model = SubstModel::<Q>::new(&[], &[subst_changed_param]);
-    let tkf_cost = TKF92CostBuilder::new(0.1, 0.2, 0.3, subst_model, phylo)
+    let tkf_cost = TKF92CostBuilder::new(&[0.1, 0.2, 0.3], subst_model, phylo)
         .build()
         .unwrap();
     let new_logl = ModelSearchCost::cost(&tkf_cost);
@@ -867,9 +861,10 @@ fn modify_tkf92_indel_params_costs_match_template<Q: QMatrix + QMatrixMaker>() {
     let subst_model = SubstModel::<Q>::new(&[], &[]);
     let tkf_original_mu = 0.2;
     let tkf_changed_mu = 0.25;
-    let mut tkf_cost = TKF92CostBuilder::new(0.1, tkf_original_mu, 0.3, subst_model, phylo.clone())
-        .build()
-        .unwrap();
+    let mut tkf_cost =
+        TKF92CostBuilder::new(&[0.1, tkf_original_mu, 0.3], subst_model, phylo.clone())
+            .build()
+            .unwrap();
 
     // sanity check
     let logl = ModelSearchCost::cost(&tkf_cost);
@@ -883,7 +878,7 @@ fn modify_tkf92_indel_params_costs_match_template<Q: QMatrix + QMatrixMaker>() {
 
     // The likelihood should be the same if we rebuild from scratch with the same modification
     let subst_model = SubstModel::<Q>::new(&[], &[]);
-    let tkf_cost = TKF92CostBuilder::new(0.1, tkf_changed_mu, 0.3, subst_model, phylo)
+    let tkf_cost = TKF92CostBuilder::new(&[0.1, tkf_changed_mu, 0.3], subst_model, phylo)
         .build()
         .unwrap();
     let new_logl = ModelSearchCost::cost(&tkf_cost);
@@ -930,7 +925,7 @@ fn tkf_udpate_tree() {
     let lambda = 0.1;
     let mu = 0.2;
     let r = 0.3;
-    let mut tkf_cost = TKF92CostBuilder::new(lambda, mu, r, subst_model.clone(), phylo.clone())
+    let mut tkf_cost = TKF92CostBuilder::new(&[lambda, mu, r], subst_model.clone(), phylo.clone())
         .build()
         .unwrap();
     let original_logl = TreeSearchCost::cost(&tkf_cost);
@@ -949,7 +944,7 @@ fn tkf_udpate_tree() {
         msa: tkf_cost.masa().clone(),
         tree: tkf_cost.tree().clone(),
     };
-    let clean_cost = TKF92CostBuilder::new(lambda, mu, r, subst_model.clone(), new_phylo)
+    let clean_cost = TKF92CostBuilder::new(&[lambda, mu, r], subst_model.clone(), new_phylo)
         .build()
         .unwrap();
     let clean_logl = TreeSearchCost::cost(&clean_cost);

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -511,19 +511,20 @@ fn tkf92_param_range() {
 
 #[test]
 fn tkf92_fixed_param_range() {
-    let tkf_cost =
-        TKF92FixedIndelCostBuilder::new(1.0, 2.0, 0.3, vec![], setup_test_phylo(Alphabet::dna()))
-            .build()
-            .unwrap();
+    let tkf_cost = TKF92FixedIndelCostBuilder::new(
+        &[1.0, 2.0, 0.3],
+        vec![],
+        setup_test_phylo(Alphabet::dna()),
+    )
+    .build()
+    .unwrap();
     tkf92_indel_param_range(&tkf_cost);
 }
 
 #[test]
 fn tkf92_add_param_range() {
     let tkf_cost = TKF92IndelAddBlocksCostBuilder::new(
-        1.0,
-        2.0,
-        0.3,
+        &[1.0, 2.0, 0.3],
         vec![],
         setup_test_phylo(Alphabet::dna()),
     )
@@ -703,6 +704,24 @@ fn tkf91_cost_builder_fails() {
 }
 
 #[test]
+fn tkf91_build_default() {
+    let tkf_indel_cost = TKF91IndelCostBuilder::new(&[], setup_test_phylo(Alphabet::dna()))
+        .build()
+        .unwrap();
+    assert_eq!(tkf_indel_cost.model.lambda(), DEFAULT_LAMBDA);
+    assert_eq!(tkf_indel_cost.model.mu(), DEFAULT_MU);
+}
+
+#[test]
+fn tkf91_build_default_one_param() {
+    let tkf_indel_cost = TKF91IndelCostBuilder::new(&[0.0331], setup_test_phylo(Alphabet::dna()))
+        .build()
+        .unwrap();
+    assert_eq!(tkf_indel_cost.model.lambda(), DEFAULT_LAMBDA);
+    assert_eq!(tkf_indel_cost.model.mu(), DEFAULT_MU);
+}
+
+#[test]
 fn tkf92_cost_builder_fails() {
     let phylo = setup_test_phylo(Alphabet::protein());
     let subst_model = SubstModel::<GTR>::new(&[], &[]);
@@ -713,6 +732,36 @@ fn tkf92_cost_builder_fails() {
         tkf92_err, Err(Error::Alphabet(msg)) if msg.contains(
         "alphabet mismatch between model and alignment")
     );
+}
+
+#[test]
+fn tkf92_build_default() {
+    let tkf_indel_cost = TKF92IndelCostBuilder::new(&[], setup_test_phylo(Alphabet::dna()))
+        .build()
+        .unwrap();
+    assert_eq!(tkf_indel_cost.model.lambda(), DEFAULT_LAMBDA);
+    assert_eq!(tkf_indel_cost.model.mu(), DEFAULT_MU);
+}
+
+#[test]
+fn tkf92_build_default_one_param() {
+    let tkf_indel_cost = TKF92IndelCostBuilder::new(&[0.0331], setup_test_phylo(Alphabet::dna()))
+        .build()
+        .unwrap();
+    assert_eq!(tkf_indel_cost.model.lambda(), DEFAULT_LAMBDA);
+    assert_eq!(tkf_indel_cost.model.mu(), DEFAULT_MU);
+    assert_eq!(tkf_indel_cost.model.r(), DEFAULT_R);
+}
+
+#[test]
+fn tkf92_fixed_build_default() {
+    let tkf_indel_cost =
+        TKF92FixedIndelCostBuilder::new(&[], vec![], setup_test_phylo(Alphabet::dna()))
+            .build()
+            .unwrap();
+    assert_eq!(tkf_indel_cost.model.lambda(), DEFAULT_LAMBDA);
+    assert_eq!(tkf_indel_cost.model.mu(), DEFAULT_MU);
+    assert_eq!(tkf_indel_cost.model.r(), DEFAULT_R);
 }
 
 #[test]

--- a/phylo/src/tkf_model/tests.rs
+++ b/phylo/src/tkf_model/tests.rs
@@ -741,6 +741,7 @@ fn tkf92_build_default() {
         .unwrap();
     assert_eq!(tkf_indel_cost.model.lambda(), DEFAULT_LAMBDA);
     assert_eq!(tkf_indel_cost.model.mu(), DEFAULT_MU);
+    assert_eq!(tkf_indel_cost.model.r(), DEFAULT_R);
 }
 
 #[test]

--- a/phylo/src/tkf_model/tkf91.rs
+++ b/phylo/src/tkf_model/tkf91.rs
@@ -12,7 +12,7 @@ use crate::tkf_model::{
     TKFCost, TKFIndelCost, TKFIndelModelInfo, TKFModel, DEFAULT_LAMBDA, DEFAULT_LAMBDA_MU_RATIO,
     DEFAULT_MU,
 };
-use crate::{bail, Result};
+use crate::Result;
 
 #[derive(Debug, Eq, PartialEq, FromPrimitive, IntoPrimitive)]
 #[repr(usize)]
@@ -98,27 +98,35 @@ impl Display for TKF91IndelModel {
 /// Validates the TKF indel parameters lambda and mu. If they are not valid, they are set to
 /// default values and a warning is logged.
 /// Returns valid (lambda, mu).
-pub(super) fn validate_lambda_and_mu(lambda: f64, mu: f64) -> (f64, f64) {
-    let mut valid_lambda = lambda;
-    let mut valid_mu = mu;
+pub(super) fn validate_lambda_mu(params: &mut [f64]) {
+    let lambda_id = usize::from(TKF91Parameters::Lambda);
+    let mu_id = usize::from(TKF91Parameters::Mu);
+    let lambda = params[lambda_id];
+    let mu = params[mu_id];
+
     if lambda <= 0.0 && mu <= 0.0 {
         warn!(
             "Both lambda and mu must be positive. Setting lambda to {DEFAULT_LAMBDA} and mu to {DEFAULT_MU}."
         );
-        valid_lambda = DEFAULT_LAMBDA;
-        valid_mu = DEFAULT_MU;
+        params[lambda_id] = DEFAULT_LAMBDA;
+        params[mu_id] = DEFAULT_MU;
     } else if lambda <= 0.0 {
-        valid_lambda = DEFAULT_LAMBDA_MU_RATIO * mu;
+        params[lambda_id] = DEFAULT_LAMBDA_MU_RATIO * mu;
         warn!(
-            "Tried to set lambda to invalid value {lambda}. It must be in (0, mu) with mu = {mu}. Setting lambda to {DEFAULT_LAMBDA_MU_RATIO}*mu = {valid_lambda}",
+            "Tried to set lambda to invalid value {lambda}. \
+            It must be in (0, mu) with mu = {mu}. \
+            Setting lambda to {DEFAULT_LAMBDA_MU_RATIO}*mu = {}",
+            params[lambda_id]
         );
     } else if mu <= lambda {
-        valid_mu = lambda / DEFAULT_LAMBDA_MU_RATIO;
+        params[mu_id] = lambda / DEFAULT_LAMBDA_MU_RATIO;
         warn!(
-            "Tried to set mu to invalid value {mu}. It must be in (lambda, infinity) with lambda = {lambda}. Setting mu to lambda/{DEFAULT_LAMBDA_MU_RATIO} = {valid_mu}"
+            "Tried to set mu to invalid value {mu}. \
+            It must be in (lambda, infinity) with lambda = {lambda}. \
+            Setting mu to lambda/{DEFAULT_LAMBDA_MU_RATIO} = {}",
+            params[mu_id]
         );
     }
-    (valid_lambda, valid_mu)
 }
 
 /// Builder for the cost using the [`TKF91IndelModel`], i.e., without a substitution model.
@@ -136,16 +144,19 @@ impl<AA: AncestralAlignment> TKF91IndelCostBuilder<AA> {
     }
 
     pub fn build(self) -> Result<TKFIndelCost<TKF91IndelModel, AA>> {
-        let mut params = self.params.clone();
-        if params.len() < 2 {
-            warn!("Too few values provided for TKF91, 2 values required, lambda and mu");
+        let mut params = self.params;
+        if params.len() != 2 {
+            warn!(
+                "Expected 2 parameters for TKF91 model (lambda, mu), but got {}",
+                params.len()
+            );
             warn!("Falling back to default values");
-            params = vec![DEFAULT_LAMBDA, DEFAULT_MU];
+            params.resize(2, 0.0);
+            params[usize::from(TKF91Parameters::Lambda)] = DEFAULT_LAMBDA;
+            params[usize::from(TKF91Parameters::Mu)] = DEFAULT_MU;
         }
-        let (lambda, mu) = validate_lambda_and_mu(params[0], params[1]);
-        let model = TKF91IndelModel {
-            params: vec![lambda, mu],
-        };
+        validate_lambda_mu(&mut params);
+        let model = TKF91IndelModel { params };
         let info = TKFIndelModelInfo::new(&model, &self.phylo);
         Ok(TKFIndelCost {
             model,
@@ -172,27 +183,7 @@ impl<Q: QMatrix, AA: AncestralAlignment> TKF91CostBuilder<Q, AA> {
     }
 
     pub fn build(self) -> Result<TKFCost<Q, TKF91IndelModel, AA>> {
-        if self.phylo.msa.alphabet() != Q::alphabet() {
-            bail!(Alphabet, "alphabet mismatch between model and alignment");
-        }
-
-        let mut params = self.params.clone();
-        if params.len() < 2 {
-            warn!("Too few values provided for TKF91, 2 values required, lambda and mu");
-            warn!("Falling back to default values");
-            params = vec![DEFAULT_LAMBDA, DEFAULT_MU];
-        }
-        let (lambda, mu) = validate_lambda_and_mu(params[0], params[1]);
-        let model = TKF91IndelModel {
-            params: vec![lambda, mu],
-        };
-        let info = TKFIndelModelInfo::new(&model, &self.phylo);
-        let indel_cost = TKFIndelCost {
-            model,
-            phylo: self.phylo.clone(),
-            model_info: RefCell::new(info),
-        };
-
+        let indel_cost = TKF91IndelCostBuilder::new(&self.params, self.phylo.clone()).build()?;
         let subst_cost = SCB::new(self.subst_model, self.phylo.clone()).build()?;
         Ok(TKFCost {
             indel_cost,

--- a/phylo/src/tkf_model/tkf91.rs
+++ b/phylo/src/tkf_model/tkf91.rs
@@ -123,18 +123,26 @@ pub(super) fn validate_lambda_and_mu(lambda: f64, mu: f64) -> (f64, f64) {
 
 /// Builder for the cost using the [`TKF91IndelModel`], i.e., without a substitution model.
 pub struct TKF91IndelCostBuilder<AA: AncestralAlignment> {
-    lambda: f64,
-    mu: f64,
+    params: Vec<f64>,
     phylo: PhyloInfo<AA>,
 }
 
 impl<AA: AncestralAlignment> TKF91IndelCostBuilder<AA> {
-    pub fn new(lambda: f64, mu: f64, phylo: PhyloInfo<AA>) -> Self {
-        Self { lambda, mu, phylo }
+    pub fn new(params: &[f64], phylo: PhyloInfo<AA>) -> Self {
+        Self {
+            params: params.to_vec(),
+            phylo,
+        }
     }
 
     pub fn build(self) -> Result<TKFIndelCost<TKF91IndelModel, AA>> {
-        let (lambda, mu) = validate_lambda_and_mu(self.lambda, self.mu);
+        let mut params = self.params.clone();
+        if params.len() < 2 {
+            warn!("Too few values provided for TKF91, 2 values required, lambda and mu");
+            warn!("Falling back to default values");
+            params = vec![DEFAULT_LAMBDA, DEFAULT_MU];
+        }
+        let (lambda, mu) = validate_lambda_and_mu(params[0], params[1]);
         let model = TKF91IndelModel {
             params: vec![lambda, mu],
         };
@@ -149,17 +157,15 @@ impl<AA: AncestralAlignment> TKF91IndelCostBuilder<AA> {
 
 /// Builder for the TKF91 cost, i.e., with a substitution model.
 pub struct TKF91CostBuilder<Q: QMatrix, AA: AncestralAlignment> {
-    lambda: f64,
-    mu: f64,
+    params: Vec<f64>,
     subst_model: SubstModel<Q>,
     phylo: PhyloInfo<AA>,
 }
 
 impl<Q: QMatrix, AA: AncestralAlignment> TKF91CostBuilder<Q, AA> {
-    pub fn new(lambda: f64, mu: f64, subst_model: SubstModel<Q>, phylo: PhyloInfo<AA>) -> Self {
+    pub fn new(params: &[f64], subst_model: SubstModel<Q>, phylo: PhyloInfo<AA>) -> Self {
         Self {
-            lambda,
-            mu,
+            params: params.to_vec(),
             subst_model,
             phylo,
         }
@@ -170,19 +176,27 @@ impl<Q: QMatrix, AA: AncestralAlignment> TKF91CostBuilder<Q, AA> {
             bail!(Alphabet, "alphabet mismatch between model and alignment");
         }
 
-        let (lambda, mu) = validate_lambda_and_mu(self.lambda, self.mu);
+        let mut params = self.params.clone();
+        if params.len() < 2 {
+            warn!("Too few values provided for TKF91, 2 values required, lambda and mu");
+            warn!("Falling back to default values");
+            params = vec![DEFAULT_LAMBDA, DEFAULT_MU];
+        }
+        let (lambda, mu) = validate_lambda_and_mu(params[0], params[1]);
         let model = TKF91IndelModel {
             params: vec![lambda, mu],
         };
         let info = TKFIndelModelInfo::new(&model, &self.phylo);
-        let tkf_cost = TKFIndelCost {
+        let indel_cost = TKFIndelCost {
             model,
             phylo: self.phylo.clone(),
             model_info: RefCell::new(info),
         };
+
+        let subst_cost = SCB::new(self.subst_model, self.phylo.clone()).build()?;
         Ok(TKFCost {
-            indel_cost: tkf_cost,
-            subst_cost: SCB::new(self.subst_model, self.phylo).build().unwrap(),
+            indel_cost,
+            subst_cost,
         })
     }
 }

--- a/phylo/src/tkf_model/tkf92.rs
+++ b/phylo/src/tkf_model/tkf92.rs
@@ -10,10 +10,10 @@ use crate::likelihood::{ParamRange, PARAM_RANGE_UNIT_INTERVAL_EXCLUSIVE};
 use crate::phylo_info::PhyloInfo;
 use crate::substitution_models::{QMatrix, SubstModel, SubstitutionCostBuilder as SCB};
 use crate::tkf_model::{
-    validate_lambda_and_mu, TKFCost, TKFIndelCost, TKFIndelModelInfo, TKFModel, DEFAULT_LAMBDA,
+    validate_lambda_mu, TKFCost, TKFIndelCost, TKFIndelModelInfo, TKFModel, DEFAULT_LAMBDA,
     DEFAULT_MU, DEFAULT_R,
 };
-use crate::{bail, Result};
+use crate::Result;
 
 #[derive(Debug, Eq, PartialEq, FromPrimitive, IntoPrimitive)]
 #[repr(usize)]
@@ -126,18 +126,25 @@ impl Display for TKF92IndelModel {
 /// Validates the TKF92 parameter `r`. If it is not valid, it is set to
 /// its default value and a warning is logged.
 /// Returns valid `r`.
-pub(super) fn validate_r(r: f64) -> f64 {
-    let mut valid_r = r;
+pub(super) fn validate_r(params: &mut [f64]) {
+    let r_id = usize::from(TKF92Parameters::R);
+    let r = params[r_id];
     if r == 0.0 {
-        valid_r = DEFAULT_R;
+        params[r_id] = DEFAULT_R;
         warn!(
-            "Tried to set r to invalid value 0. It must be in (0, 1). Setting r to {valid_r}. Hint: r = 0 yields special case: TKF91 model, consider using that instead."
+            "Tried to set r to invalid value 0. \
+            It must be in (0, 1). Setting r to {}. \
+            Hint: r = 0 yields special case: TKF91 model, consider using that instead.",
+            params[r_id]
         );
     } else if r <= 0.0 || r >= 1.0 {
-        valid_r = DEFAULT_R;
-        warn!("Tried to set r to invalid value {r}. It must be in (0, 1). Setting r to {valid_r}.");
+        params[r_id] = DEFAULT_R;
+        warn!(
+            "Tried to set r to invalid value {r}. \
+            It must be in (0, 1). Setting r to {}.",
+            params[r_id]
+        );
     }
-    valid_r
 }
 
 /// Builder for the cost using the [`TKF92IndelModel`], i.e., without a substitution model.
@@ -155,16 +162,24 @@ impl<AA: AncestralAlignment> TKF92IndelCostBuilder<AA> {
     }
 
     pub fn build(self) -> Result<TKFIndelCost<TKF92IndelModel, AA>> {
-        let mut params = self.params.clone();
-        if params.len() < 3 {
-            warn!("Too few values provided for TKF92, 3 values required, lambda, mu and r");
+        let mut params = self.params;
+        if params.len() != 3 {
+            warn!(
+                "Expected 3 parameters for TKF92 model (lambda, mu, r), but got {}",
+                params.len()
+            );
             warn!("Falling back to default values");
-            params = vec![DEFAULT_LAMBDA, DEFAULT_MU, DEFAULT_R];
+            params.resize(3, 0.0);
+            params[usize::from(TKF92Parameters::Lambda)] = DEFAULT_LAMBDA;
+            params[usize::from(TKF92Parameters::Mu)] = DEFAULT_MU;
+            params[usize::from(TKF92Parameters::R)] = DEFAULT_R;
+        } else {
+            validate_lambda_mu(&mut params);
+            validate_r(&mut params);
         }
-        let (lambda, mu) = validate_lambda_and_mu(params[0], params[1]);
-        let r = validate_r(params[2]);
+        let r = params[usize::from(TKF92Parameters::R)];
         let model = TKF92IndelModel {
-            params: vec![lambda, mu, r],
+            params,
             log_r: r.ln(),
             one_minus_r_over_r: (1.0 - r) / r,
         };
@@ -194,29 +209,7 @@ impl<Q: QMatrix, AA: AncestralAlignment> TKF92CostBuilder<Q, AA> {
     }
 
     pub fn build(self) -> Result<TKFCost<Q, TKF92IndelModel, AA>> {
-        if self.phylo.msa.alphabet() != Q::alphabet() {
-            bail!(Alphabet, "alphabet mismatch between model and alignment");
-        }
-
-        let mut params = self.params.clone();
-        if params.len() < 3 {
-            warn!("Too few values provided for TKF92, 3 values required, lambda, mu and r");
-            warn!("Falling back to default values");
-            params = vec![DEFAULT_LAMBDA, DEFAULT_MU, DEFAULT_R];
-        }
-        let (lambda, mu) = validate_lambda_and_mu(params[0], params[1]);
-        let r = validate_r(params[2]);
-        let model = TKF92IndelModel {
-            params: vec![lambda, mu, r],
-            log_r: r.ln(),
-            one_minus_r_over_r: (1.0 - r) / r,
-        };
-        let info = TKFIndelModelInfo::new(&model, &self.phylo);
-        let indel_cost = TKFIndelCost {
-            model,
-            phylo: self.phylo.clone(),
-            model_info: RefCell::new(info),
-        };
+        let indel_cost = TKF92IndelCostBuilder::new(&self.params, self.phylo.clone()).build()?;
         let subst_cost = SCB::new(self.subst_model, self.phylo).build()?;
         Ok(TKFCost {
             indel_cost,

--- a/phylo/src/tkf_model/tkf92.rs
+++ b/phylo/src/tkf_model/tkf92.rs
@@ -142,25 +142,27 @@ pub(super) fn validate_r(r: f64) -> f64 {
 
 /// Builder for the cost using the [`TKF92IndelModel`], i.e., without a substitution model.
 pub struct TKF92IndelCostBuilder<AA: AncestralAlignment> {
-    lambda: f64,
-    mu: f64,
-    r: f64,
+    params: Vec<f64>,
     phylo: PhyloInfo<AA>,
 }
 
 impl<AA: AncestralAlignment> TKF92IndelCostBuilder<AA> {
-    pub fn new(lambda: f64, mu: f64, r: f64, phylo: PhyloInfo<AA>) -> Self {
+    pub fn new(params: &[f64], phylo: PhyloInfo<AA>) -> Self {
         Self {
-            lambda,
-            mu,
-            r,
+            params: params.to_vec(),
             phylo,
         }
     }
 
     pub fn build(self) -> Result<TKFIndelCost<TKF92IndelModel, AA>> {
-        let (lambda, mu) = validate_lambda_and_mu(self.lambda, self.mu);
-        let r = validate_r(self.r);
+        let mut params = self.params.clone();
+        if params.len() < 3 {
+            warn!("Too few values provided for TKF92, 3 values required, lambda, mu and r");
+            warn!("Falling back to default values");
+            params = vec![DEFAULT_LAMBDA, DEFAULT_MU, DEFAULT_R];
+        }
+        let (lambda, mu) = validate_lambda_and_mu(params[0], params[1]);
+        let r = validate_r(params[2]);
         let model = TKF92IndelModel {
             params: vec![lambda, mu, r],
             log_r: r.ln(),
@@ -177,25 +179,15 @@ impl<AA: AncestralAlignment> TKF92IndelCostBuilder<AA> {
 
 /// Builder for the TKF92 cost, i.e., with a substitution model.
 pub struct TKF92CostBuilder<Q: QMatrix, AA: AncestralAlignment> {
-    lambda: f64,
-    mu: f64,
-    r: f64,
+    params: Vec<f64>,
     subst_model: SubstModel<Q>,
     phylo: PhyloInfo<AA>,
 }
 
 impl<Q: QMatrix, AA: AncestralAlignment> TKF92CostBuilder<Q, AA> {
-    pub fn new(
-        lambda: f64,
-        mu: f64,
-        r: f64,
-        subst_model: SubstModel<Q>,
-        phylo: PhyloInfo<AA>,
-    ) -> Self {
+    pub fn new(params: &[f64], subst_model: SubstModel<Q>, phylo: PhyloInfo<AA>) -> Self {
         Self {
-            lambda,
-            mu,
-            r,
+            params: params.to_vec(),
             subst_model,
             phylo,
         }
@@ -206,22 +198,29 @@ impl<Q: QMatrix, AA: AncestralAlignment> TKF92CostBuilder<Q, AA> {
             bail!(Alphabet, "alphabet mismatch between model and alignment");
         }
 
-        let (lambda, mu) = validate_lambda_and_mu(self.lambda, self.mu);
-        let r = validate_r(self.r);
+        let mut params = self.params.clone();
+        if params.len() < 3 {
+            warn!("Too few values provided for TKF92, 3 values required, lambda, mu and r");
+            warn!("Falling back to default values");
+            params = vec![DEFAULT_LAMBDA, DEFAULT_MU, DEFAULT_R];
+        }
+        let (lambda, mu) = validate_lambda_and_mu(params[0], params[1]);
+        let r = validate_r(params[2]);
         let model = TKF92IndelModel {
             params: vec![lambda, mu, r],
             log_r: r.ln(),
             one_minus_r_over_r: (1.0 - r) / r,
         };
         let info = TKFIndelModelInfo::new(&model, &self.phylo);
-        let tkf_cost = TKFIndelCost {
+        let indel_cost = TKFIndelCost {
             model,
             phylo: self.phylo.clone(),
             model_info: RefCell::new(info),
         };
+        let subst_cost = SCB::new(self.subst_model, self.phylo).build()?;
         Ok(TKFCost {
-            indel_cost: tkf_cost,
-            subst_cost: SCB::new(self.subst_model, self.phylo).build().unwrap(),
+            indel_cost,
+            subst_cost,
         })
     }
 }

--- a/phylo/src/tkf_model/tkf92_additional_blocks.rs
+++ b/phylo/src/tkf_model/tkf92_additional_blocks.rs
@@ -8,7 +8,7 @@ use crate::likelihood::{ParamRange, PARAM_RANGE_UNIT_INTERVAL_EXCLUSIVE};
 use crate::phylo_info::PhyloInfo;
 use crate::tkf_model::{
     blocks_of_alignment, merge_fragmentation_with_blocks, validate_fragmentation,
-    validate_lambda_and_mu, validate_r, TKF92Parameters, TKFIndelCost, TKFIndelModelInfo, TKFModel,
+    validate_lambda_mu, validate_r, TKF92Parameters, TKFIndelCost, TKFIndelModelInfo, TKFModel,
 };
 use crate::Result;
 
@@ -112,38 +112,30 @@ impl Display for TKF92IndelModelAddBlocks {
 
 /// Builder for the cost using the [`TKF92IndelModelAddBlocks`].
 pub struct TKF92IndelAddBlocksCostBuilder<AA: AncestralAlignment> {
-    lambda: f64,
-    mu: f64,
-    r: f64,
+    params: Vec<f64>,
     phylo: PhyloInfo<AA>,
     additional_blocks: Vec<usize>,
 }
 
 #[cfg(test)]
 impl<AA: AncestralAlignment> TKF92IndelAddBlocksCostBuilder<AA> {
-    pub fn new(
-        lambda: f64,
-        mu: f64,
-        r: f64,
-        additional_blocks: Vec<usize>,
-        phylo: PhyloInfo<AA>,
-    ) -> Self {
+    pub fn new(params: &[f64], additional_blocks: Vec<usize>, phylo: PhyloInfo<AA>) -> Self {
         Self {
-            lambda,
-            mu,
-            r,
+            params: params.to_vec(),
             phylo,
             additional_blocks,
         }
     }
 
     pub fn build(self) -> Result<TKFIndelCost<TKF92IndelModelAddBlocks, AA>> {
-        let (lambda, mu) = validate_lambda_and_mu(self.lambda, self.mu);
-        let r = validate_r(self.r);
+        let mut params = self.params;
+        validate_lambda_mu(&mut params);
+        validate_r(&mut params);
         let additional_blocks =
             validate_fragmentation(&self.additional_blocks, self.phylo.msa.len());
+        let r = params[usize::from(TKF92Parameters::R)];
         let model = TKF92IndelModelAddBlocks {
-            params: vec![lambda, mu, r],
+            params,
             log_r: r.ln(),
             one_minus_r_over_r: (1.0 - r) / r,
             additional_blocks,
@@ -235,9 +227,7 @@ mod private_tests {
         let additional_blocks = vec![2, 4];
 
         let tkf92_cost = TKF92IndelAddBlocksCostBuilder::new(
-            lambda,
-            mu,
-            r,
+            &[lambda, mu, r],
             additional_blocks,
             phylo_info.clone(),
         )
@@ -249,10 +239,13 @@ mod private_tests {
 
         let fragmentations = [vec![2, 4], vec![2, 4, 5], vec![2, 4, 7], vec![2, 4, 5, 7]];
         for fragmentation in fragmentations {
-            let fragment_cost =
-                TKF92FixedIndelCostBuilder::new(lambda, mu, r, fragmentation, phylo_info.clone())
-                    .build()
-                    .unwrap();
+            let fragment_cost = TKF92FixedIndelCostBuilder::new(
+                &[lambda, mu, r],
+                fragmentation,
+                phylo_info.clone(),
+            )
+            .build()
+            .unwrap();
             sum_over_fragmentations_cost += fragment_cost.logl().exp();
         }
         sum_over_fragmentations_cost = sum_over_fragmentations_cost.ln();

--- a/phylo/src/tkf_model/tkf92_fixed_fragmentation.rs
+++ b/phylo/src/tkf_model/tkf92_fixed_fragmentation.rs
@@ -5,14 +5,14 @@ use log::warn;
 use num_enum::FromPrimitive;
 use rstest::rstest;
 
+use crate::alignment::AncestralAlignment;
 use crate::likelihood::{ParamRange, PARAM_RANGE_UNIT_INTERVAL_EXCLUSIVE};
 use crate::phylo_info::PhyloInfo;
 use crate::tkf_model::{
-    blocks_of_alignment, validate_lambda_and_mu, validate_r, TKF92Parameters, TKFIndelCost,
-    TKFIndelModelInfo,
+    blocks_of_alignment, validate_lambda_mu, validate_r, TKF92Parameters, TKFIndelCost,
+    TKFIndelModelInfo, TKFModel, DEFAULT_LAMBDA, DEFAULT_MU, DEFAULT_R,
 };
 use crate::Result;
-use crate::{alignment::AncestralAlignment, tkf_model::TKFModel};
 
 /// TKF92 indel model with a `fixed fragmentation` (and without a substitution model),
 /// which means that the provided fragmentation will be regarded as the true fragmentation.
@@ -151,9 +151,7 @@ impl Display for TKF92FixedIndelModel {
 /// Builder for the cost using the [`TKF92FixedIndelModel`].
 #[cfg(test)]
 pub struct TKF92FixedIndelCostBuilder<AA: AncestralAlignment> {
-    lambda: f64,
-    mu: f64,
-    r: f64,
+    params: Vec<f64>,
     fragmentation: Vec<usize>,
     phylo: PhyloInfo<AA>,
 }
@@ -183,28 +181,34 @@ pub(super) fn validate_fragmentation(fragmentation: &[usize], msa_len: usize) ->
 
 #[cfg(test)]
 impl<AA: AncestralAlignment> TKF92FixedIndelCostBuilder<AA> {
-    pub fn new(
-        lambda: f64,
-        mu: f64,
-        r: f64,
-        fragmentation: Vec<usize>,
-        phylo: PhyloInfo<AA>,
-    ) -> Self {
+    pub fn new(params: &[f64], fragmentation: Vec<usize>, phylo: PhyloInfo<AA>) -> Self {
         Self {
-            lambda,
-            mu,
-            r,
+            params: params.to_vec(),
             fragmentation,
             phylo,
         }
     }
 
     pub fn build(self) -> Result<TKFIndelCost<TKF92FixedIndelModel, AA>> {
-        let (lambda, mu) = validate_lambda_and_mu(self.lambda, self.mu);
-        let r = validate_r(self.r);
+        let mut params = self.params;
+        let lambda_id = usize::from(TKF92Parameters::Lambda);
+        let mu_id = usize::from(TKF92Parameters::Mu);
+        let r_id = usize::from(TKF92Parameters::R);
+        if params.len() < 3 {
+            warn!("Too few values provided for TKF92, 3 values required, lambda, mu and r");
+            warn!("Falling back to default values");
+            params.resize(3, 0.0);
+            params[lambda_id] = DEFAULT_LAMBDA;
+            params[mu_id] = DEFAULT_MU;
+            params[r_id] = DEFAULT_R;
+        } else {
+            validate_lambda_mu(&mut params);
+            validate_r(&mut params);
+        }
         let fragmentation = validate_fragmentation(&self.fragmentation, self.phylo.msa.len());
+        let r = params[r_id];
         let model = TKF92FixedIndelModel {
-            params: vec![lambda, mu, r],
+            params,
             log_r: r.ln(),
             fragmentation,
         };
@@ -296,10 +300,13 @@ mod private_tests {
         ];
 
         for fragmentation in fragmentations {
-            let fragment_cost =
-                TKF92FixedIndelCostBuilder::new(lambda, mu, r, fragmentation, phylo_info.clone())
-                    .build()
-                    .unwrap();
+            let fragment_cost = TKF92FixedIndelCostBuilder::new(
+                &[lambda, mu, r],
+                fragmentation,
+                phylo_info.clone(),
+            )
+            .build()
+            .unwrap();
             sum_over_fragmentations_cost += fragment_cost.logl().exp();
         }
         sum_over_fragmentations_cost = sum_over_fragmentations_cost.ln();
@@ -343,10 +350,13 @@ mod private_tests {
         ];
 
         for fragmentation in fragmentations {
-            let fragment_cost =
-                TKF92FixedIndelCostBuilder::new(lambda, mu, r, fragmentation, phylo_info.clone())
-                    .build()
-                    .unwrap();
+            let fragment_cost = TKF92FixedIndelCostBuilder::new(
+                &[lambda, mu, r],
+                fragmentation,
+                phylo_info.clone(),
+            )
+            .build()
+            .unwrap();
             sum_over_fragmentations_cost += fragment_cost.logl().exp();
         }
         sum_over_fragmentations_cost = sum_over_fragmentations_cost.ln();
@@ -411,7 +421,7 @@ mod private_tests {
         ];
         // parameters from simulation
         let fragment_cost =
-            TKF92FixedIndelCostBuilder::new(1.0, 1.1, 0.5, fragmentation, phylo_info)
+            TKF92FixedIndelCostBuilder::new(&[1.0, 1.1, 0.5], fragmentation, phylo_info)
                 .build()
                 .unwrap();
         // logl from simulation

--- a/phylo/src/tkf_model/tkf92_fixed_fragmentation.rs
+++ b/phylo/src/tkf_model/tkf92_fixed_fragmentation.rs
@@ -194,8 +194,11 @@ impl<AA: AncestralAlignment> TKF92FixedIndelCostBuilder<AA> {
         let lambda_id = usize::from(TKF92Parameters::Lambda);
         let mu_id = usize::from(TKF92Parameters::Mu);
         let r_id = usize::from(TKF92Parameters::R);
-        if params.len() < 3 {
-            warn!("Too few values provided for TKF92, 3 values required, lambda, mu and r");
+        if params.len() != 3 {
+            warn!(
+                "Expected 3 parameters for TKF92 model (lambda, mu, r), but got {}",
+                params.len()
+            );
             warn!("Falling back to default values");
             params.resize(3, 0.0);
             params[lambda_id] = DEFAULT_LAMBDA;

--- a/phylo/src/tkf_model/tkf92_fixed_fragmentation.rs
+++ b/phylo/src/tkf_model/tkf92_fixed_fragmentation.rs
@@ -278,7 +278,7 @@ mod private_tests {
         let mu = 1.1;
         let r = 0.5;
 
-        let tkf92_cost = TKF92IndelCostBuilder::new(lambda, mu, r, phylo_info.clone())
+        let tkf92_cost = TKF92IndelCostBuilder::new(&[lambda, mu, r], phylo_info.clone())
             .build()
             .unwrap();
         let cost = tkf92_cost.logl();
@@ -322,7 +322,7 @@ mod private_tests {
         let mu = 1.1;
         let r = 0.5;
 
-        let tkf92_cost = TKF92IndelCostBuilder::new(lambda, mu, r, phylo_info.clone())
+        let tkf92_cost = TKF92IndelCostBuilder::new(&[lambda, mu, r], phylo_info.clone())
             .build()
             .unwrap();
         let cost = tkf92_cost.logl();

--- a/phylo/src/tkf_model/tkf_indel.rs
+++ b/phylo/src/tkf_model/tkf_indel.rs
@@ -549,12 +549,12 @@ mod private_tests {
 
     #[cfg(test)]
     fn validate_lambda_mu(l: f64, m: f64, l_expected: f64, m_expected: f64) {
-        let cost = TKF91IndelCostBuilder::new(l, m, setup_test_phylo(Alphabet::dna()))
+        let cost = TKF91IndelCostBuilder::new(&[l, m], setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
         assert_eq!(cost.model.lambda(), l_expected);
         assert_eq!(cost.model.mu(), m_expected);
-        let cost = TKF92IndelCostBuilder::new(l, m, 0.1, setup_test_phylo(Alphabet::dna()))
+        let cost = TKF92IndelCostBuilder::new(&[l, m, 0.1], setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
         assert_eq!(cost.model.lambda(), l_expected);
@@ -563,7 +563,7 @@ mod private_tests {
 
     #[cfg(test)]
     fn validate_r(r: f64, r_expected: f64) {
-        let cost = TKF92IndelCostBuilder::new(1.0, 2.0, r, setup_test_phylo(Alphabet::dna()))
+        let cost = TKF92IndelCostBuilder::new(&[1.0, 2.0, r], setup_test_phylo(Alphabet::dna()))
             .build()
             .unwrap();
         assert_eq!(cost.model.r(), r_expected);


### PR DESCRIPTION
## Summary
- Refactored `TKF91IndelCostBuilder`, `TKF91CostBuilder`, `TKF92IndelCostBuilder`, and `TKF92CostBuilder` to accept parameter slices (`&[f64]`) in their `new` methods, aligning them with the `PIPModel::new` pattern.
- Added parameter validation logic to handle missing values by providing defaults and logging warnings.
- Updated all test call sites and internal references to use the new slice-based API.

Closes #164