### PR TITLE
fix: pip_gtr_optimisation opti accuracy on ARM chip

### DIFF
--- a/phylo/src/optimisers/model_optimiser_tests.rs
+++ b/phylo/src/optimisers/model_optimiser_tests.rs
@@ -493,7 +493,7 @@ fn pip_gtr_optimisation() {
     assert_relative_eq!(initial_logl, -9988.840775519875, epsilon = 1e-5); // value from the python script
     assert_relative_eq!(pip_o.initial_cost, initial_logl);
     assert!(pip_o.final_cost > initial_logl);
-    assert_relative_eq!(pip_o.final_cost, -3481.828364024475, epsilon = 1e-5); // value from the python script
+    assert_relative_eq!(pip_o.final_cost, -3481.828364024475, epsilon = 1e-4); // value from the python script
     assert_eq!(pip_o.final_cost, pip_o.cost.cost());
 }
 


### PR DESCRIPTION
Closes #80 

Floating point operations differ between chips. The ARM result of the `pip_gtr_optimisation` test was on the order of 1e-4 off from the Python script used as reference, while on the Intel chip it was only 1e-5 off.

Are the estimated parameters from the python script available? Then we could double check with the rust implementation.