### PR TITLE
Fix/report error on duplicate ids newick

### DIFF
--- a/phylo/src/phylo_info/phyloinfo_builder.rs
+++ b/phylo/src/phylo_info/phyloinfo_builder.rs
@@ -311,7 +311,7 @@ pub(crate) fn set_missing_tree_node_ids(tree: &Tree) -> Result<Tree> {
             tree_with_all_ids.nodes[usize::from(node_idx)].id = new_id.clone();
             info!("Set missing id of node {node_idx} to {new_id}");
         } else if !seen_user_set_ids.insert(id.to_string()) {
-            bail!(Tree, "duplicate id ({id}) found in the leaves of the tree");
+            bail!(Tree, "duplicate node id ({id}) found in the tree");
         }
     }
     Ok(tree_with_all_ids)
@@ -454,13 +454,13 @@ mod private_tests {
 
     #[test]
     fn set_missing_tree_node_ids_finds_duplicate() {
-        let tree = tree!("((A1:1.0, B1:1.0) I1:1.0,(C2:1.0,(D3:1.0, A1:1.0) I9:1.0):1.0):1.0;");
+        let tree = tree!("((A1:1.0, B1:1.0) I1:1.0,(C2:1.0,(D3:1.0, E4:1.0) I1:1.0):1.0):1.0;");
 
-        let error = set_missing_tree_node_ids(&tree);
+        let error: Result<tree::Tree, Error> = set_missing_tree_node_ids(&tree);
 
         assert_matches!(
             error,
-            Err(Error::Tree(msg)) if msg.contains("duplicate id (A1) found in the leaves of the tree")
+            Err(Error::Tree(msg)) if msg.contains("duplicate node id (I1) found in the tree")
         );
     }
 

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -238,7 +238,7 @@ impl Tree {
                     .iter()
                     .map(|&child_idx| self.to_newick_subroot(child_idx))
                     .collect();
-                format!("({}){}:{}", children_newick.join(","), &node.id, node.blen)
+                format!("({}){}:{}", children_newick.join(","), node.id, node.blen)
             }
         }
     }

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -371,7 +371,7 @@ impl Tree {
             if !seen.insert(self.node_id(node_idx)) {
                 bail!(
                     Tree,
-                    "node ID '{}' is not unique in the tree",
+                    "duplicate node id ({}) found in the tree",
                     self.node_id(node_idx)
                 );
             }

--- a/phylo/src/tree/mod.rs
+++ b/phylo/src/tree/mod.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
 use std::fmt::{Debug, Display};
 
 use fixedbitset::FixedBitSet;
+use hashbrown::HashSet;
 use inc_stats::Percentiles;
 
 use crate::alignment::Sequences;
@@ -65,7 +65,7 @@ pub struct Tree {
     pub(crate) nodes: Vec<Node>,
     postorder: Vec<NodeIdx>,
     preorder: Vec<NodeIdx>,
-    leaf_ids: Vec<String>,
+    leaf_ids: HashSet<String>,
     pub complete: bool,
     /// The number of leaves in the tree.
     pub n: usize,
@@ -316,7 +316,7 @@ impl Tree {
         order
     }
 
-    pub fn leaf_ids(&self) -> Vec<String> {
+    pub fn leaf_ids(&self) -> HashSet<String> {
         debug_assert!(self.complete);
         self.leaf_ids.clone()
     }

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -102,7 +102,7 @@ fn node_ids_not_unique() {
     let error = tree.node_ids_are_unique();
 
     assert_matches!(
-        error, Err(Error::Tree(msg)) if msg.contains("not unique")
+        error, Err(Error::Tree(msg)) if msg.contains("duplicate node id")
     );
 }
 

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
 use approx::assert_relative_eq;
 use assert_matches::assert_matches;
 use fixedbitset::FixedBitSet;
+use hashbrown::HashSet;
 use itertools::repeat_n;
 use pest::error::ErrorVariant;
 use rand::{rng, Rng};
@@ -521,7 +521,7 @@ fn test_to_newick_simple() {
         complete: false,
         n: 3,
         length: 8.5,
-        leaf_ids: vec!["A".to_string(), "B".to_string()],
+        leaf_ids: HashSet::from_iter(["A".to_string(), "B".to_string()]),
         dirty: FixedBitSet::with_capacity(3),
     };
     assert_eq!(tree.to_newick(), "((A:1,B:5.5)C:2);");

--- a/phylo/src/tree/tests.rs
+++ b/phylo/src/tree/tests.rs
@@ -401,6 +401,18 @@ fn newick_garbage() {
 }
 
 #[test]
+fn newick_with_duplicate_leaf_ids() {
+    let trees = from_newick("((A:1.0,B:1.0):2.0,(A:1.0,D:1.0):3.0):4.0;");
+    assert_matches!(trees, Err(Error::Tree(msg)) if msg.contains("duplicate leaf id (A) found in the tree"));
+}
+
+#[test]
+fn newick_duplicate_internal_ids_ignored() {
+    let trees = from_newick("((A1:1.0, B1:1.0) I1:1.0,(C2:1.0,(D3:1.0, E4:1.0) I1:1.0):1.0):1.0;");
+    assert!(trees.is_ok());
+}
+
+#[test]
 fn parse_scientific_floats() {
     let tree = tree!(
         "((((A:.00001,B:1.4e-10)F:2.25e3,C:-0.546)G:1.00030000,D:+003.95)H:1.0e-10,E:4.0e0)I:-.005;"

--- a/phylo/src/tree/tree_parser.rs
+++ b/phylo/src/tree/tree_parser.rs
@@ -1,9 +1,7 @@
-use std::result::Result as stdResult;
-
 use fixedbitset::FixedBitSet;
 use hashbrown::HashSet;
 use log::{info, warn};
-use pest::{error::Error as PestError, iterators::Pair, Parser};
+use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 
 use crate::bail;
@@ -34,15 +32,11 @@ pub fn from_newick(newick: &str) -> Result<Vec<Tree>> {
                 let tmp = tree_rule.into_inner().next();
                 if let Some(rule) = tmp {
                     let mut tree = Tree::new_empty();
-                    let res = match rule.as_rule() {
-                        Rule::rooted => tree.parse_rooted_rule(rule),
-                        Rule::unrooted => tree.parse_unrooted_rule(rule),
+                    match rule.as_rule() {
+                        Rule::rooted => tree.parse_rooted_rule(rule)?,
+                        Rule::unrooted => tree.parse_unrooted_rule(rule)?,
                         _ => unimplemented!(),
                     };
-                    if let Err(e) = res {
-                        bail!(TreeParsing, "malformed newick string", e);
-                    }
-
                     trees.push(tree);
                 }
             }
@@ -68,7 +62,7 @@ impl Tree {
         }
     }
 
-    fn parse_rooted_rule(&mut self, node_rule: Pair<Rule>) -> stdResult<(), Box<PestError<Rule>>> {
+    fn parse_rooted_rule(&mut self, node_rule: Pair<Rule>) -> Result<()> {
         let tree_rule = node_rule.into_inner().next().unwrap();
         let mut node_idx = 0;
         let mut parent_stack = Vec::<usize>::new();
@@ -97,10 +91,7 @@ impl Tree {
         self.dirty = FixedBitSet::with_capacity(self.n * 2 - 1);
     }
 
-    fn parse_unrooted_rule(
-        &mut self,
-        tree_rule: Pair<Rule>,
-    ) -> stdResult<(), Box<PestError<Rule>>> {
+    fn parse_unrooted_rule(&mut self, tree_rule: Pair<Rule>) -> Result<()> {
         warn!("Found unrooted tree, will root at the trifurcation");
         let mut node_idx = 0;
         let mut parent_stack = Vec::<usize>::new();
@@ -144,7 +135,7 @@ impl Tree {
         node_idx: &mut usize,
         stack: &mut Vec<usize>,
         internal_rule: Pair<Rule>,
-    ) -> stdResult<(), Box<PestError<Rule>>> {
+    ) -> Result<()> {
         let mut id = String::from("");
         let mut blen = 0.0;
         let mut children: Vec<NodeIdx> = Vec::new();
@@ -179,11 +170,7 @@ impl Tree {
         Ok(())
     }
 
-    fn parse_leaf_rule(
-        &mut self,
-        node_idx: &mut usize,
-        inner_rule: Pair<Rule>,
-    ) -> stdResult<(), Box<PestError<Rule>>> {
+    fn parse_leaf_rule(&mut self, node_idx: &mut usize, inner_rule: Pair<Rule>) -> Result<()> {
         let mut id = String::from("");
         let mut blen = 0.0;
         for rule in inner_rule.into_inner() {
@@ -195,7 +182,9 @@ impl Tree {
         }
         self.nodes
             .push(Node::new_leaf(*node_idx, None, blen, id.clone()));
-        self.leaf_ids.insert(id);
+        if !self.leaf_ids.insert(id.clone()) {
+            bail!(Tree, "duplicate node ID '{}' found in the tree", id);
+        }
         *node_idx += 1;
         Ok(())
     }

--- a/phylo/src/tree/tree_parser.rs
+++ b/phylo/src/tree/tree_parser.rs
@@ -183,7 +183,7 @@ impl Tree {
         self.nodes
             .push(Node::new_leaf(*node_idx, None, blen, id.clone()));
         if !self.leaf_ids.insert(id.clone()) {
-            bail!(Tree, "duplicate node ID '{}' found in the tree", id);
+            bail!(Tree, "duplicate leaf id ({}) found in the tree", id);
         }
         *node_idx += 1;
         Ok(())

--- a/phylo/src/tree/tree_parser.rs
+++ b/phylo/src/tree/tree_parser.rs
@@ -1,6 +1,7 @@
 use std::result::Result as stdResult;
 
 use fixedbitset::FixedBitSet;
+use hashbrown::HashSet;
 use log::{info, warn};
 use pest::{error::Error as PestError, iterators::Pair, Parser};
 use pest_derive::Parser;
@@ -62,7 +63,7 @@ impl Tree {
             complete: false,
             n: 0,
             length: 0.0,
-            leaf_ids: Vec::new(),
+            leaf_ids: HashSet::new(),
             dirty: FixedBitSet::new(),
         }
     }
@@ -194,7 +195,7 @@ impl Tree {
         }
         self.nodes
             .push(Node::new_leaf(*node_idx, None, blen, id.clone()));
-        self.leaf_ids.push(id);
+        self.leaf_ids.insert(id);
         *node_idx += 1;
         Ok(())
     }


### PR DESCRIPTION
Newick trees with duplicate leaf ids now throw an error during the parsing stage.

Partially addresses #146.